### PR TITLE
Bump python version to 3.6.6

### DIFF
--- a/Dockerfile.k8s
+++ b/Dockerfile.k8s
@@ -1,4 +1,4 @@
-FROM python:3.6.5-stretch
+FROM python:3.6.6-stretch
 
 WORKDIR /neuromation
 


### PR DESCRIPTION
_platform-registry-api_ and  _platform-storage-api_ use `python:3.6.6-stretch` as base image
Lets use it instead `python:3.6.5-stretch` for _platform-api_ too