### PR TITLE
Restore users from github in case they do not exist.

### DIFF
--- a/deploy/jumphost/docker/entrypoint.sh
+++ b/deploy/jumphost/docker/entrypoint.sh
@@ -66,7 +66,7 @@ users=(
 
 for user in ${users[@]}; do
     echo $user
-    if [ ! -d "$DIRECTORY" ]; then
+    if [ ! -d "/home/${name}" ]; then
         adduser -d /home/${name} ${name};
         chown -R ${name}:${name} /home/${name};
         curl https://github.com/${user}.keys >> /home/${user}/.ssh/authorized_keys


### PR DESCRIPTION
We have number of default users that we would like to have by default on bastion host.
This is extension of the user restoration script - create our github users on system deployment.

Closes https://github.com/neuromation/platform-api/issues/256