### PR TITLE
Add unit tests on consistency between Job's to_primitive and from_primitive

### DIFF
--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -600,6 +600,21 @@ class TestJobRequest:
         )
         assert request.container == expected_container
 
+    def test_to_and_from_primitive(self, job_request_payload):
+        actual = JobRequest.to_primitive(JobRequest.from_primitive(job_request_payload))
+        assert actual == job_request_payload
+
+    def test_to_and_from_primitive_with_shm(self, job_request_payload_with_shm):
+        actual = JobRequest.to_primitive(
+            JobRequest.from_primitive(job_request_payload_with_shm)
+        )
+        assert actual == job_request_payload_with_shm
+
+    def test_to_and_from_primitive_with_ssh(self, job_request_payload):
+        job_request_payload["container"]["ssh_server"] = {"port": 678}
+        actual = JobRequest.to_primitive(JobRequest.from_primitive(job_request_payload))
+        assert actual == job_request_payload
+
 
 class TestContainerHTTPServer:
     def test_from_primitive(self):


### PR DESCRIPTION
In case when we add new fields to Job, we can possibly forget to add assertions on these fields in other tests. The new tests assert consistency between `to_primitive` & `from_primitive` operations.

NOTE: Merge only after https://github.com/neuromation/platform-api/pull/278