### PR TITLE
Update openssl library on circle ci virtual box.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,11 +102,10 @@ jobs:
           command: |
             pyenv install --debug 3.6.3
             pyenv local 3.6.3-debug
-            sudo apt-get update
-            sudo apt-get install nfs-common
             sudo apt-get install -y software-properties-common
             sudo add-apt-repository -y ppa:0k53d-karl-f830m/openssl
             sudo apt-get update
+            sudo apt-get install nfs-common
             export DEBIAN_FRONTEND="noninteractive"
             sudo apt-get install -y -q openssl
 


### PR DESCRIPTION
As a part of GCP StackDriver integration, since we need to sign JWT tokens on the server side and test functionality, we would like to update openssl library on circle ci virtual machine.