### PR TITLE
Fix flaky integration tests: wait until status != pending

### DIFF
--- a/platform_api/handlers/models_handler.py
+++ b/platform_api/handlers/models_handler.py
@@ -101,6 +101,8 @@ class ModelsHandler:
             payload["ssh_server"] = job.ssh_server
         if job.internal_hostname:
             payload["internal_hostname"] = job.internal_hostname
+        if job.description:
+            payload["description"] = job.description
         return payload
 
     async def handle_post(self, request):

--- a/tests/integration/test_kube_orchestrator.py
+++ b/tests/integration/test_kube_orchestrator.py
@@ -957,7 +957,7 @@ class TestPodContainerDevShmSettings:
     async def test_shm_extended_not_requested_try_create_huge_file(
         self, kube_config, kube_client, delete_pod_later
     ):
-        command = "dd if=/dev/zero of=/dev/shm/test  bs=999999M  count=1"
+        command = "dd if=/dev/zero of=/dev/zero  bs=999999M  count=1"
         resources = ContainerResources(cpu=0.1, memory_mb=128, shm=False)
         run_output = await self.run_command_get_status(
             kube_config, kube_client, delete_pod_later, resources, command


### PR DESCRIPTION
in the new test we didn't wait until the killed job turns into state "succeeded" => flaky test.