### PR TITLE
Revert PR#304: Response with HTTPGone when killing a non-running job

### DIFF
--- a/platform_api/handlers/jobs_handler.py
+++ b/platform_api/handlers/jobs_handler.py
@@ -280,9 +280,7 @@ class JobsHandler:
         logger.info("Checking whether %r has %r", user, permission)
         await check_permission(request, permission.action, [permission])
 
-        if not await self._jobs_service.delete_job(job_id):
-            raise aiohttp.web.HTTPGone(text=f"Job {job_id} is not running")
-
+        await self._jobs_service.delete_job(job_id)
         raise aiohttp.web.HTTPNoContent()
 
     async def stream_log(self, request):

--- a/platform_api/orchestrator/jobs_service.py
+++ b/platform_api/orchestrator/jobs_service.py
@@ -103,12 +103,10 @@ class JobsService:
         job.is_deleted = True
         await self._jobs_storage.set_job(job)
 
-    async def delete_job(self, job_id: str) -> bool:
+    async def delete_job(self, job_id: str) -> None:
         job = await self._jobs_storage.get_job(job_id)
         if not job.is_finished:
             await self._delete_job(job)
-            return True
-        return False
 
     async def get_all_jobs(self) -> List[Job]:
         return await self._jobs_storage.get_all_jobs()

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -10,7 +10,6 @@ from aiohttp.web import (
     HTTPAccepted,
     HTTPBadRequest,
     HTTPForbidden,
-    HTTPGone,
     HTTPNoContent,
     HTTPOk,
     HTTPUnauthorized,
@@ -115,11 +114,6 @@ class JobsClient:
         async with self._client.delete(url, headers=self._headers) as response:
             assert response.status == HTTPNoContent.status_code
 
-    async def delete_finished_job(self, job_id: str):
-        url = self._api_config.generate_job_url(job_id)
-        async with self._client.delete(url, headers=self._headers) as response:
-            assert response.status == HTTPGone.status_code
-
 
 @pytest.fixture
 async def jobs_client(api, client, regular_user):
@@ -185,7 +179,7 @@ class TestModels:
         assert retrieved_job["internal_hostname"] == expected_internal_hostname
 
         await jobs_client.long_polling_by_job_id(job_id=job_id, status="succeeded")
-        await jobs_client.delete_finished_job(job_id=job_id)
+        await jobs_client.delete_job(job_id=job_id)
 
     @pytest.mark.asyncio
     async def test_create_model_with_ssh_and_http(
@@ -204,7 +198,7 @@ class TestModels:
             assert result["ssh_server"] == expected_url
 
         await jobs_client.long_polling_by_job_id(job_id=job_id, status="succeeded")
-        await jobs_client.delete_finished_job(job_id=job_id)
+        await jobs_client.delete_job(job_id=job_id)
 
     @pytest.mark.asyncio
     async def test_create_model_with_ssh_only(
@@ -224,7 +218,7 @@ class TestModels:
             assert result["ssh_server"] == expected_url
 
         await jobs_client.long_polling_by_job_id(job_id=job_id, status="succeeded")
-        await jobs_client.delete_finished_job(job_id=job_id)
+        await jobs_client.delete_job(job_id=job_id)
 
     @pytest.mark.asyncio
     async def test_create_unknown_gpu_model(
@@ -303,7 +297,7 @@ class TestModels:
             assert result["status"] in ["pending"]
             job_id = result["job_id"]
         await jobs_client.long_polling_by_job_id(job_id=job_id, status="succeeded")
-        await jobs_client.delete_finished_job(job_id=job_id)
+        await jobs_client.delete_job(job_id=job_id)
 
     @pytest.mark.asyncio
     async def test_incorrect_request(self, api, client, regular_user):
@@ -519,7 +513,7 @@ class TestJobs:
         assert set(jobs_ids) <= {x["id"] for x in jobs}
         # clean
         for job in jobs:
-            await jobs_client.delete_finished_job(job_id=job["id"])
+            await jobs_client.delete_job(job_id=job["id"])
 
     @pytest.mark.asyncio
     async def test_delete_job(
@@ -534,7 +528,7 @@ class TestJobs:
             assert result["status"] in ["pending"]
             job_id = result["job_id"]
             await jobs_client.long_polling_by_job_id(job_id=job_id, status="succeeded")
-        await jobs_client.delete_finished_job(job_id=job_id)
+        await jobs_client.delete_job(job_id=job_id)
 
         jobs = await jobs_client.get_all_jobs()
         assert len(jobs) == 1
@@ -556,7 +550,8 @@ class TestJobs:
             job_id = result["job_id"]
             await jobs_client.long_polling_by_job_id(job_id=job_id, status="running")
         await jobs_client.delete_job(job_id=job_id)
-        await jobs_client.delete_finished_job(job_id=job_id)
+        # delete again (same result expected)
+        await jobs_client.delete_job(job_id=job_id)
 
     @pytest.mark.asyncio
     async def test_delete_not_exist(self, api, client, regular_user):


### PR DESCRIPTION
The PR https://github.com/neuromation/platform-api/pull/304 (Response with HTTPGone when killing a non-running job) introduced super-flaky tests, reverting this PR.

The reason was the following: in platform-api, `Job.is_finished` does not always reflects the real state of the pod (there are some places where we manually assign it). Nonetheless, in PR https://github.com/neuromation/platform-api/pull/304 the descision whether we should `delete` the job or not was set up to be dependent on `Job.is_finished`, thus, on dev environment, this field was inconsistent with real state of the kubernetes pod, and the tests on deletion already deleted jobs failed.