### PR TITLE
Fixed the SSH server failure

### DIFF
--- a/platform_api/orchestrator/kube_orchestrator.py
+++ b/platform_api/orchestrator/kube_orchestrator.py
@@ -144,7 +144,9 @@ def convert_pod_status_to_job_status(pod_status: PodStatus) -> JobStatusItem:
 
 
 class KubeOrchestrator(Orchestrator):
-    def __init__(self, *, config: KubeConfig, es_client: Elasticsearch) -> None:
+    def __init__(
+        self, *, config: KubeConfig, es_client: Optional[Elasticsearch] = None
+    ) -> None:
         self._loop = asyncio.get_event_loop()
 
         self._config = config
@@ -429,6 +431,7 @@ class KubeOrchestrator(Orchestrator):
             return False
 
     async def get_job_log_reader(self, job: Job) -> LogReader:
+        assert self._es_client
         pod_name = self._get_job_pod_name(job)
         if await self._check_pod_exists(pod_name):
             return PodContainerLogReader(


### PR DESCRIPTION
fixes
```
2018-12-24 14:17:54,401 - platform_api.ssh.server - INFO - Initializing Orchestrator
Traceback (most recent call last):
  File "/usr/local/bin/api-ssh-server", line 11, in <module>
    load_entry_point('platform-api', 'console_scripts', 'api-ssh-server')()
  File "/neuromation/platform_api/ssh/server.py", line 207, in main
    loop.run_until_complete(run())
  File "/usr/local/lib/python3.6/asyncio/base_events.py", line 468, in run_until_complete
    return future.result()
  File "/neuromation/platform_api/ssh/server.py", line 191, in run
    async with KubeOrchestrator(config=config.orchestrator) as orchestrator:
TypeError: __init__() missing 1 required keyword-only argument: 'es_client'
```