### PR TITLE
Add test on description in model train response (#289)

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -152,6 +152,7 @@ async def model_request_factory():
             },
             "dataset_storage_uri": f"storage://{owner}",
             "result_storage_uri": f"storage://{owner}/result",
+            "description": "test job submitted by neuro model train",
         }
 
     return _factory
@@ -187,6 +188,7 @@ class TestModels:
             expected_internal_hostname = f"{job_id}.default"
             assert result["internal_hostname"] == expected_internal_hostname
             assert result["is_preemptible"]
+            assert result["description"] == "test job submitted by neuro model train"
 
         retrieved_job = await jobs_client.get_job_by_id(job_id=job_id)
         assert retrieved_job["internal_hostname"] == expected_internal_hostname


### PR DESCRIPTION
Fixes the old issue https://github.com/neuromation/platform-api/issues/289.
Somehow the "description" field was added to the response without tests in PR https://github.com/neuromation/platform-api/pull/334, current PR adds the check of this field in an integration test.