### PR TITLE
add helm values for HSE environment

### DIFF
--- a/deploy/README
+++ b/deploy/README
@@ -1,8 +1,52 @@
 
+# Deploy in HSE cluster
+
+###  _cd_ to _deploy_ folder
+``` cd deploy ```
+
+### Connect to cluster
+```gcloud container clusters get-credentials hse-cluster-01 --zone us-central1-a --project light-reality-205619```
+
+### Deploy platform
+Platform api
+```helm --set "global.env=hse" upgrade --install platformapi platformapi```
+
+SSH-Auth
+```helm --set "global.env=hse" upgrade --install ssh-auth ssh_auth```
+
+Jumphost
+```helm --set "global.env=hse" upgrade --install jumphost jumphost/helmpackage```
+
+
+
+#Deploy in stagging and dev clusters
+
+
+## Platform api
+
 Dev : 
-	- helm --set "global.env=dev" install platformapi --name=platformapi
-        - helm install traefik --name=traefik
+	```helm --set "global.env=dev" upgrade --install platformapi platformapi```
 
 Stage : 
-	- helm --set "global.env=stage" install platformapi --name=platformapi
-        - helm install traefik --name=traefik
+	```helm --set "global.env=staging" upgrade --install platformapi platformapi```
+
+
+
+## SSH-Auth
+
+Dev :
+	```helm --set "global.env=dev" upgrade --install ssh-auth ssh_auth```
+
+Stage :
+	```helm --set "global.env=staging" upgrade --install ssh-auth ssh_auth```
+
+
+
+
+## Jumphost
+
+Dev :
+	```helm --set "global.env=dev" upgrade --install jumphost jumphost/helmpackage```
+
+Stage :
+	```helm --set "global.env=staging" upgrade --install jumphost jumphost/helmpackage```

--- a/deploy/jumphost/helmpackage/values.yaml
+++ b/deploy/jumphost/helmpackage/values.yaml
@@ -7,3 +7,4 @@ VOLUME:
   _default: jumphost-dev2
   dev: jumphost-dev2
   staging: jumphost-stage
+  hse: jumphost-hse

--- a/deploy/platformapi/values.yaml
+++ b/deploy/platformapi/values.yaml
@@ -2,39 +2,49 @@ IMAGE:
   _default: gcr.io/light-reality-205619/platformapi-k8s:latest
   dev: gcr.io/light-reality-205619/platformapi-k8s:latest
   staging: gcr.io/light-reality-205619/platformapi-k8s:latest
+  hse: gcr.io/light-reality-205619/platformapi-k8s:latest
 NP_STORAGE_NFS_SERVER:
   _default: '10.76.126.154'
   dev: '10.76.126.154'
   staging: '10.69.59.50'
+  hse: '10.60.201.234'
 NP_STORAGE_NFS_PATH:
   _default: '/dev2premium'
   dev: '/dev2premium'
   staging: '/devpremium'
+  hse: '/hse_premium'
 NP_K8S_JOBS_INGRESS_DOMAIN_NAME:
   _default: jobs.platform.dev.neuromation.io
   dev: jobs.platform.dev.neuromation.io
   staging: jobs.platform.staging.neuromation.io
+  hse: jobs.platform.hse.neuromation.io
 NP_K8S_SSH_INGRESS_DOMAIN_NAME:
   _default: ssh.platform.dev.neuromation.io
   dev: ssh.platform.dev.neuromation.io
   staging: ssh.platform.staging.neuromation.io
+  hse: ssh.platform.hse.neuromation.io
 NP_K8S_SSH_AUTH_INGRESS_DOMAIN_NAME:
   _default: ssh-auth.dev.neuromation.io
   dev: ssh-auth.dev.neuromation.io
   staging: ssh-auth.staging.neuromation.io
+  hse: ssh-auth.hse.neuromation.io
 INGRESS_HOST:
   _default: platform.dev.neuromation.io
   dev: platform.dev.neuromation.io
   staging: platform.staging.neuromation.io
+  hse: platform.hse.neuromation.io
 NP_DB_REDIS_URI:
   _default: redis://10.0.0.11:6379/0
   dev: redis://10.0.0.11:6379/0
   staging: redis://10.0.0.3:6379/1
+  hse: redis://10.0.0.19:6379/0
 NP_REGISTRY_HOST:
   _default: registry.dev.neuromation.io
   dev: registry.dev.neuromation.io
   staging: registry.staging.neuromation.io
+  hse: registry.hse.neuromation.io
 NP_GKE_GPU_MODELS:
   _default: nvidia-tesla-k80,nvidia-tesla-p4,nvidia-tesla-v100
   dev: nvidia-tesla-k80,nvidia-tesla-p4,nvidia-tesla-v100
   staging: nvidia-tesla-k80,nvidia-tesla-p4,nvidia-tesla-v100
+  hse: nvidia-tesla-k80,nvidia-tesla-p4,nvidia-tesla-v100

--- a/deploy/ssh_auth/values.yaml
+++ b/deploy/ssh_auth/values.yaml
@@ -2,7 +2,9 @@ IMAGE:
   _default: gcr.io/light-reality-205619/ssh-auth:latest
   dev: gcr.io/light-reality-205619/ssh-auth:latest
   staging: gcr.io/light-reality-205619/ssh-auth:latest
+  hse: gcr.io/light-reality-205619/ssh-auth:latest
 NP_DB_REDIS_URI:
   _default: redis://10.0.0.11:6379/0
   dev: redis://10.0.0.11:6379/0
   staging: redis://10.0.0.3:6379/1
+  hse: redis://10.0.0.19:6379/0


### PR DESCRIPTION
add helm values for HSE environment for platform-api, jumphost and ssh-auth.
for now, manual can be done - instructions at https://github.com/neuromation/platform-api/blob/manual-deploy-in-hse/deploy/README#L2 -  as HSE is a temp environment.

If is needed to add automation via cicleci - need to decide the flow - from which branch we should deploy in HSE culster
