### PR TITLE
Fix flaky job filtration tests

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -550,7 +550,7 @@ class TestJobs:
         url = api.model_base_url
         headers = regular_user.headers
         model_request = model_request_factory(regular_user.name)
-        model_request["container"]["resources"]["memory_mb"] = 100500
+        model_request["container"]["resources"]["memory_mb"] = 100_500
         async with client.post(url, headers=headers, json=model_request) as resp:
             assert resp.status == HTTPAccepted.status_code
             result = await resp.json()


### PR DESCRIPTION
Fix flaky test introduced in PR #435
1. add long polling for the jobs to run
2. add new test on wrong status