### PR TITLE
Fix error with setting environment variable NP_REGISTRY_HTTPS

### DIFF
--- a/deploy/platformapi/templates/platformapi.gke.yml
+++ b/deploy/platformapi/templates/platformapi.gke.yml
@@ -64,7 +64,7 @@ spec:
         - name: NP_REGISTRY_HOST
           value: "{{ printf "%s" (pluck .Values.global.env .Values.NP_REGISTRY_HOST | first | default .Values.NP_REGISTRY_HOST._default) }}"
         - name: NP_REGISTRY_HTTPS
-          value: "{{ printf "%s" (pluck .Values.global.env .Values.NP_REGISTRY_HTTPS | first | default .Values.NP_REGISTRY_HTTPS._default) }}"
+          value: "true"
         - name: NP_K8S_NODE_LABEL_GPU
           value: cloud.google.com/gke-accelerator
         - name: NP_GKE_GPU_MODELS

--- a/deploy/platformapi/values.yaml
+++ b/deploy/platformapi/values.yaml
@@ -63,11 +63,6 @@ NP_REGISTRY_HOST:
   dev: registry-dev.neu.ro
   staging: registry.staging.neuromation.io
   hse: registry.hse.neuromation.io
-NP_REGISTRY_HTTPS:
-  _default: true
-  dev: true
-  staging: true
-  hse: true
 NP_GKE_GPU_MODELS:
   _default: nvidia-tesla-k80,nvidia-tesla-p4,nvidia-tesla-v100
   dev: nvidia-tesla-k80,nvidia-tesla-p4,nvidia-tesla-v100


### PR DESCRIPTION
The old value `true` of the env variable `NP_REGISTRY_HTTPS` that was set up in `deploy/platformapi/values.yaml` somehow was incorrectly retrieved in `deploy/platformapi/templates/platformapi.gke.yml` (i.e. the code `"{{ printf "%s" (pluck .Values.global.env .Values.NP_REGISTRY_HTTPS | first | default .Values.NP_REGISTRY_HTTPS._default) }}` didn't work).

The actual value was wrong:
```
root@platformapi-6d4d76c4b7-hj2dk:/neuromation# env  | grep NP_REGISTRY
NP_REGISTRY_HTTPS=%!s(bool=true)
NP_REGISTRY_HOST=registry-dev.neu.ro
```

Therefore, the url for registry (on dev cluster) was `http://` not `https://` and thus `neuro image ls` didn't work (threw Unauthorized exception).

I don't understand why the string (not boolean) value `true` was not parsed correctly to `"true"`, but this quickfix follows the pattern (that actually works) of another "bool" variable `NP_K8S_JOBS_INGRESS_HTTPS` that is also set up directly in the file `deploy/platformapi/templates/platformapi.gke.yml`