### PR TITLE
Change job name and owner name length limits

### DIFF
--- a/platform_api/handlers/validators.py
+++ b/platform_api/handlers/validators.py
@@ -21,7 +21,9 @@ USER_NAME_MAX_LENGTH = 63 - 1 - JOB_NAME_MAX_LENGTH
 OptionalString = t.String | t.Null
 
 
-def create_job_name_validator(max_length: Optional[int] = JOB_NAME_MAX_LENGTH) -> t.Trafaret:
+def create_job_name_validator(
+    max_length: Optional[int] = JOB_NAME_MAX_LENGTH
+) -> t.Trafaret:
     return t.Null | t.String(min_length=3, max_length=max_length) & t.Regexp(
         JOB_NAME_PATTERN
     )

--- a/tests/unit/test_job_rest_validator.py
+++ b/tests/unit/test_job_rest_validator.py
@@ -5,11 +5,11 @@ import trafaret as t
 
 from platform_api.handlers.jobs_handler import create_job_response_validator
 from platform_api.handlers.validators import (
+    JOB_NAME_MAX_LENGTH,
+    USER_NAME_MAX_LENGTH,
     create_job_name_validator,
     create_user_name_validator,
     create_volumes_validator,
-USER_NAME_MAX_LENGTH,
-JOB_NAME_MAX_LENGTH,
 )
 
 
@@ -49,7 +49,9 @@ class TestJobNameValidator:
     def test_invalid_job_names__too_long(self) -> None:
         value = "a" * (JOB_NAME_MAX_LENGTH + 1)
         validator = create_job_name_validator()
-        with pytest.raises(t.DataError, match=f"String is longer than {JOB_NAME_MAX_LENGTH} characters"):
+        with pytest.raises(
+            t.DataError, match=f"String is longer than {JOB_NAME_MAX_LENGTH} characters"
+        ):
             assert validator.check(value)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Closes https://github.com/neuromation/platform-api/issues/635

Since the client has tries to resolve job-name to job-ID, on each operation `neuro job {something} job-ID` the client will try to resolve `job-ID` as a job-name, therefore `job-ID` has to conform job-name validator. All job IDs on neuromation platform are of the form `job-{uuid4()}` of length 40.