### PR TITLE
Get rid of platform-specific default network policy

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -347,3 +347,15 @@ def config_with_oauth(
     config_factory: Callable[..., Config], oauth_config_dev: Optional[OAuthConfig]
 ) -> Config:
     return config_factory(oauth=oauth_config_dev)
+
+
+@pytest.fixture
+def default_network_policy_payload_factory(
+    kube_orchestrator: KubeOrchestrator
+) -> Iterator[Callable[[str, Dict[str, str]], Dict[str, Any]]]:
+    def _impl(name: str, pod_labels: Dict[str, str]) -> Dict[str, Any]:
+        # TODO (ajuszkowski, 29-04-2019) Once we abstract the network policy
+        #  rules away, we can remove private method access from here
+        return kube_orchestrator._generate_default_user_network_policy(name, pod_labels)
+
+    yield _impl

--- a/tests/integration/test_kube_orchestrator.py
+++ b/tests/integration/test_kube_orchestrator.py
@@ -3,7 +3,16 @@ import io
 import time
 import uuid
 from pathlib import PurePath
-from typing import Any, AsyncIterator, Awaitable, Callable, Iterator, Optional, Sequence
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterator,
+    Optional,
+    Sequence,
+)
 from unittest import mock
 
 import aiohttp
@@ -1075,11 +1084,17 @@ class TestKubeClient:
         kube_config: KubeConfig,
         kube_client: KubeClient,
         delete_network_policy_later: Callable[[str], Awaitable[None]],
+        default_network_policy_payload_factory: Callable[
+            [str, Dict[str, str]], Dict[str, Any]
+        ],
     ) -> None:
         name = str(uuid.uuid4())
         await delete_network_policy_later(name)
-        payload = await kube_client.create_default_network_policy(
-            name, {"testlabel": name}, namespace_name=kube_config.namespace
+        network_policy_payload = default_network_policy_payload_factory(
+            name, {"testlabel": name}
+        )
+        payload = await kube_client.create_network_policy(
+            network_policy_payload, namespace_name=kube_config.namespace
         )
         assert payload["metadata"]["name"] == name
 
@@ -1089,16 +1104,23 @@ class TestKubeClient:
         kube_config: KubeConfig,
         kube_client: KubeClient,
         delete_network_policy_later: Callable[[str], Awaitable[None]],
+        default_network_policy_payload_factory: Callable[
+            [str, Dict[str, str]], Dict[str, Any]
+        ],
     ) -> None:
         name = str(uuid.uuid4())
         await delete_network_policy_later(name)
-        payload = await kube_client.create_default_network_policy(
-            name, {"testlabel": name}, namespace_name=kube_config.namespace
+        network_policy_payload = default_network_policy_payload_factory(
+            name, {"testlabel": name}
+        )
+
+        payload = await kube_client.create_network_policy(
+            network_policy_payload, namespace_name=kube_config.namespace
         )
         assert payload["metadata"]["name"] == name
         with pytest.raises(AlreadyExistsException):
-            await kube_client.create_default_network_policy(
-                name, {"testlabel": name}, namespace_name=kube_config.namespace
+            await kube_client.create_network_policy(
+                network_policy_payload, namespace_name=kube_config.namespace
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
part of https://github.com/neuromation/platform-api/issues/606

Generalizes method `KubeClient.create_default_network_policy` to `KubeClient.create_network_policy`; defines default network policy in a private method of `KubeOrchestrator`