### PR TITLE
Temporary fix invalid DNS names for jobs with too long name

### DIFF
--- a/platform_api/handlers/jobs_handler.py
+++ b/platform_api/handlers/jobs_handler.py
@@ -34,6 +34,7 @@ from .validators import (
     create_job_name_validator,
     create_job_status_validator,
     create_user_name_validator,
+    sanitize_dns_name,
 )
 
 
@@ -163,7 +164,10 @@ def convert_job_to_job_response(job: Job) -> Dict[str, Any]:
     if job.has_http_server_exposed:
         response_payload["http_url"] = job.http_url
         if job.http_url_named:
-            response_payload["http_url_named"] = job.http_url_named
+            # TEMPORARY FIX (ayushkovskiy, May 10): Too long DNS label (longer than 63
+            # chars) is invalid, therefore we don't send it back to user (issue #642)
+            http_url_named_sanitized = sanitize_dns_name(job.http_url_named)
+            response_payload["http_url_named"] = http_url_named_sanitized
     if job.has_ssh_server_exposed:
         response_payload["ssh_server"] = job.ssh_server
     if job.internal_hostname:

--- a/platform_api/handlers/validators.py
+++ b/platform_api/handlers/validators.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Optional, Sequence, Set
 
 import trafaret as t
+from yarl import URL
 
 from platform_api.orchestrator.job_request import JobStatus
 from platform_api.resource import GPUModel
@@ -167,3 +168,16 @@ def create_container_request_validator(
 
 def create_container_response_validator() -> t.Trafaret:
     return create_container_validator(allow_volumes=True, allow_any_gpu_models=True)
+
+
+def sanitize_dns_name(value: str) -> Optional[str]:
+    """ This is a TEMPORARY METHOD used to sanitize DNS names so that they are parseable
+    by the client (issue #642).
+    :param value: String representing a DNS name
+    :return: `value` if it can be parsed by `yarl.URL`, `None` otherwise
+    """
+    try:
+        URL(value)
+        return value
+    except ValueError:
+        return None


### PR DESCRIPTION
Temporary fix of https://github.com/neuromation/platform-api/issues/642: Jobs with too long job-name don't ever have DNS name exposed.