### PR TITLE
Switch kubectl context to minikube for e2e tests

### DIFF
--- a/run_e2e_tests.sh
+++ b/run_e2e_tests.sh
@@ -2,9 +2,8 @@
 set -o verbose
 docker tag $(cat AUTH_SERVER_IMAGE_NAME) platformauthapi:latest
 
-kubectl config use-context minikube
-
 if [ ! "$CI" = true ]; then
+    kubectl config use-context minikube
     echo "Setting up external services"
     docker save -o /tmp/platformauthapi.image platformauthapi:latest
     docker save -o /tmp/platformapi.image platformapi-k8s:latest


### PR DESCRIPTION
not to break dev when running e2e tests locally