### PR TITLE
Use same targets for format and lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ lint:
 
 format:
 	isort -rc platform_api tests setup.py
-	black .
+	black platform_api tests setup.py
 
 test_unit:
 	pytest -vv --cov-config=setup.cfg --cov platform_api tests/unit


### PR DESCRIPTION
`Black` format all files inside repo root folder but lint only `platform_api tests setup.py`. Let's use identical targets for lint and format.