### PR TITLE
remove old ingress hosts

### DIFF
--- a/deploy/platformapi/templates/platformapi.gke.yml
+++ b/deploy/platformapi/templates/platformapi.gke.yml
@@ -115,36 +115,6 @@ spec:
   - host: {{ printf "%s" (pluck .Values.global.env .Values.INGRESS_HOST | first | default .Values.INGRESS_HOST._default) }}
     http:
       paths:
-      - path: /api/v1/storage
-        backend:
-          serviceName: platformstorageapi
-          servicePort: 8080
-      - path: /api/v1/users
-        backend:
-          serviceName: platformauthapi
-          servicePort: 8080
-      - path: /api/v1
-        backend:
-          serviceName: platformapi
-          servicePort: 8080
-  - host: {{ printf "%s" (pluck .Values.global.env .Values.INGRESS_HOST_TEMPORARY | first | default .Values.INGRESS_HOST_TEMPORARY._default) }}
-    http:
-      paths:
-      - path: /api/v1/storage
-        backend:
-          serviceName: platformstorageapi
-          servicePort: 8080
-      - path: /api/v1/users
-        backend:
-          serviceName: platformauthapi
-          servicePort: 8080
-      - path: /api/v1
-        backend:
-          serviceName: platformapi
-          servicePort: 8080
-  - host: {{ printf "%s" (pluck .Values.global.env .Values.INGRESS_HOST_TEMPORARY_NEW_DOMAIN | first | default .Values.INGRESS_HOST_TEMPORARY_NEW_DOMAIN._default) }}
-    http:
-      paths:
       - path: /oauth
         backend:
           serviceName: platformingressauth

--- a/deploy/platformapi/values.yaml
+++ b/deploy/platformapi/values.yaml
@@ -44,16 +44,6 @@ NP_JOBS_INGRESS_OAUTH_AUTHORIZE_URL:
   staging: https://staging.neu.ro/oauth/authorize
   prod: https://neu.ro/oauth/authorize
 INGRESS_HOST:
-  _default: platform.dev.neuromation.io
-  dev: platform.dev.neuromation.io
-  staging: platform.staging.neuromation.io
-  prod: platform.prod.neuromation.io
-INGRESS_HOST_TEMPORARY:
-  _default: dev.ai.neuromation.io
-  dev: dev.ai.neuromation.io
-  staging: staging.ai.neuromation.io
-  prod: ai.neuromation.io
-INGRESS_HOST_TEMPORARY_NEW_DOMAIN:
   _default: dev.neu.ro
   dev: dev.neu.ro
   staging: staging.neu.ro


### PR DESCRIPTION
remove extra `INGRESS_HOST_TEMPORARY` and `INGRESS_HOST_TEMPORARY_NEW_DOMAIN`
keep only `INGRESS_HOST` with proper values