### PR TITLE
Expose the key of jobs pod tolerations

### DIFF
--- a/platform_api/api.py
+++ b/platform_api/api.py
@@ -265,6 +265,7 @@ async def get_cluster_configs(config: Config) -> Sequence[ClusterConfig]:
         return await client.get_clusters(
             jobs_ingress_class=config.jobs.jobs_ingress_class,
             jobs_ingress_oauth_url=config.jobs.jobs_ingress_oauth_url,
+            jobs_pod_toleration_key=config.jobs.jobs_pod_toleration_key,
         )
 
 

--- a/platform_api/cluster_config_factory.py
+++ b/platform_api/cluster_config_factory.py
@@ -26,12 +26,14 @@ class ClusterConfigFactory:
         *,
         jobs_ingress_class: str,
         jobs_ingress_oauth_url: URL,
+        jobs_pod_toleration_key: str,
     ) -> Sequence[ClusterConfig]:
         configs = (
             self._create_cluster_config(
                 p,
                 jobs_ingress_class=jobs_ingress_class,
                 jobs_ingress_oauth_url=jobs_ingress_oauth_url,
+                jobs_pod_toleration_key=jobs_pod_toleration_key,
             )
             for p in payload
         )
@@ -43,6 +45,7 @@ class ClusterConfigFactory:
         *,
         jobs_ingress_class: str,
         jobs_ingress_oauth_url: URL,
+        jobs_pod_toleration_key: str,
     ) -> Optional[ClusterConfig]:
         try:
             _cluster_config_validator.check(payload)
@@ -54,6 +57,7 @@ class ClusterConfigFactory:
                     payload,
                     jobs_ingress_class=jobs_ingress_class,
                     jobs_ingress_oauth_url=jobs_ingress_oauth_url,
+                    jobs_pod_toleration_key=jobs_pod_toleration_key,
                 ),
                 ingress=self._create_ingress_config(payload),
             )
@@ -91,6 +95,7 @@ class ClusterConfigFactory:
         payload: Dict[str, Any],
         jobs_ingress_class: str,
         jobs_ingress_oauth_url: URL,
+        jobs_pod_toleration_key: str,
     ) -> OrchestratorConfig:
         orchestrator = payload["orchestrator"]
         kube = orchestrator["kubernetes"]
@@ -114,6 +119,7 @@ class ClusterConfigFactory:
             namespace=kube["namespace"],
             jobs_ingress_class=jobs_ingress_class,
             jobs_ingress_oauth_url=jobs_ingress_oauth_url,
+            jobs_pod_toleration_key=jobs_pod_toleration_key,
             node_label_gpu=kube["node_label_gpu"],
             node_label_preemptible=kube["node_label_preemptible"],
         )

--- a/platform_api/config.py
+++ b/platform_api/config.py
@@ -60,6 +60,7 @@ class JobsConfig:
     orphaned_job_owner: str = ""
     jobs_ingress_class: str = "traefik"
     jobs_ingress_oauth_url: URL = URL("https://neu.ro/oauth/authorize")
+    jobs_pod_toleration_key: str = "platform.neuromation.io/job"
 
     @property
     def deletion_delay(self) -> timedelta:

--- a/platform_api/config_client.py
+++ b/platform_api/config_client.py
@@ -63,7 +63,11 @@ class ConfigClient:
             yield response
 
     async def get_clusters(
-        self, *, jobs_ingress_class: str, jobs_ingress_oauth_url: URL
+        self,
+        *,
+        jobs_ingress_class: str,
+        jobs_ingress_oauth_url: URL,
+        jobs_pod_toleration_key: str,
     ) -> Sequence[ClusterConfig]:
         async with self._request("GET", "clusters") as response:
             payload = await response.json()
@@ -71,4 +75,5 @@ class ConfigClient:
                 payload,
                 jobs_ingress_class=jobs_ingress_class,
                 jobs_ingress_oauth_url=jobs_ingress_oauth_url,
+                jobs_pod_toleration_key=jobs_pod_toleration_key,
             )

--- a/platform_api/config_factory.py
+++ b/platform_api/config_factory.py
@@ -78,6 +78,9 @@ class EnvironConfigFactory:
             jobs_ingress_oauth_url=URL(
                 self._environ["NP_JOBS_INGRESS_OAUTH_AUTHORIZE_URL"]
             ),
+            jobs_pod_toleration_key=self._environ.get(
+                "NP_JOBS_POD_TOLERATION_KEY", JobsConfig.jobs_pod_toleration_key
+            ),
         )
 
     def create_ssh(self) -> SSHConfig:
@@ -198,6 +201,9 @@ class EnvironConfigFactory:
             ),
             jobs_ingress_oauth_url=URL(
                 self._environ["NP_JOBS_INGRESS_OAUTH_AUTHORIZE_URL"]
+            ),
+            jobs_pod_toleration_key=self._environ.get(
+                "NP_JOBS_POD_TOLERATION_KEY", KubeConfig.jobs_pod_toleration_key
             ),
             is_http_ingress_secure=self._get_bool("NP_K8S_JOBS_INGRESS_HTTPS"),
             jobs_domain_name_template=self._environ[

--- a/tests/integration/test_config_client.py
+++ b/tests/integration/test_config_client.py
@@ -81,6 +81,7 @@ class TestConfigClient:
                 result = await client.get_clusters(
                     jobs_ingress_class="nginx",
                     jobs_ingress_oauth_url=URL("https://neu.ro/oauth/authorize"),
+                    jobs_pod_toleration_key="platform.neuromation.io/job",
                 )
 
                 assert len(result) == 1
@@ -95,6 +96,7 @@ class TestConfigClient:
                 result = await client.get_clusters(
                     jobs_ingress_class="nginx",
                     jobs_ingress_oauth_url=URL("https://neu.ro/oauth/authorize"),
+                    jobs_pod_toleration_key="platform.neuromation.io/job",
                 )
 
                 assert len(result) == 1

--- a/tests/unit/test_cluster_config_factory.py
+++ b/tests/unit/test_cluster_config_factory.py
@@ -182,12 +182,18 @@ def jobs_ingress_oauth_url() -> URL:
     return URL("https://neu.ro/oauth/authorize")
 
 
+@pytest.fixture
+def jobs_pod_toleration_key() -> str:
+    return "platform.neuromation.io/job"
+
+
 class TestClusterConfigFactory:
     def test_valid_cluster_config(
         self,
         clusters_payload: Sequence[Dict[str, Any]],
         jobs_ingress_class: str,
         jobs_ingress_oauth_url: URL,
+        jobs_pod_toleration_key: str,
     ) -> None:
         storage_payload = clusters_payload[0]["storage"]
         registry_payload = clusters_payload[0]["registry"]
@@ -201,6 +207,7 @@ class TestClusterConfigFactory:
             clusters_payload,
             jobs_ingress_class=jobs_ingress_class,
             jobs_ingress_oauth_url=jobs_ingress_oauth_url,
+            jobs_pod_toleration_key=jobs_pod_toleration_key,
         )
 
         assert len(clusters) == 1
@@ -314,6 +321,7 @@ class TestClusterConfigFactory:
         clusters_payload: Sequence[Dict[str, Any]],
         jobs_ingress_class: str,
         jobs_ingress_oauth_url: URL,
+        jobs_pod_toleration_key: str,
     ) -> None:
         storage_payload = clusters_payload[0]["storage"]
 
@@ -322,6 +330,7 @@ class TestClusterConfigFactory:
             clusters_payload,
             jobs_ingress_class=jobs_ingress_class,
             jobs_ingress_oauth_url=jobs_ingress_oauth_url,
+            jobs_pod_toleration_key=jobs_pod_toleration_key,
         )
         cluster = clusters[0]
 
@@ -395,6 +404,7 @@ class TestClusterConfigFactory:
         clusters_payload: List[Dict[str, Any]],
         jobs_ingress_class: str,
         jobs_ingress_oauth_url: URL,
+        jobs_pod_toleration_key: str,
     ) -> None:
         clusters_payload.append({})
         factory = ClusterConfigFactory()
@@ -402,6 +412,7 @@ class TestClusterConfigFactory:
             clusters_payload,
             jobs_ingress_class=jobs_ingress_class,
             jobs_ingress_oauth_url=jobs_ingress_oauth_url,
+            jobs_pod_toleration_key=jobs_pod_toleration_key,
         )
 
         assert len(clusters) == 1

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -182,6 +182,7 @@ class TestEnvironConfigFactory:
         assert cluster.orchestrator.jobs_ingress_oauth_url == URL(
             "http://neu.ro/oauth/authorize"
         )
+        assert config.jobs.jobs_pod_toleration_key == "platform.neuromation.io/job"
         assert cluster.orchestrator.client_conn_pool_size == 100
         assert not cluster.orchestrator.is_http_ingress_secure
         assert cluster.orchestrator.jobs_domain_name_template == "{job_id}.jobs.domain"
@@ -190,6 +191,10 @@ class TestEnvironConfigFactory:
         assert cluster.orchestrator.resource_pool_types == [ResourcePoolType()]
         assert cluster.orchestrator.node_label_gpu is None
         assert cluster.orchestrator.node_label_preemptible is None
+        assert (
+            cluster.orchestrator.jobs_pod_toleration_key
+            == "platform.neuromation.io/job"
+        )
 
         assert config.database.redis is None
 
@@ -246,6 +251,7 @@ class TestEnvironConfigFactory:
             "NP_K8S_JOBS_INGRESS_DOMAIN_NAME_TEMPLATE": "{job_id}.jobs.domain",
             "NP_K8S_SSH_AUTH_INGRESS_DOMAIN_NAME": "ssh-auth.domain",
             "NP_K8S_JOB_DELETION_DELAY": "3600",
+            "NP_JOBS_POD_TOLERATION_KEY": "jobs-pod-toleration-key",
             "NP_DB_REDIS_URI": "redis://localhost:6379/0",
             "NP_DB_REDIS_CONN_POOL_SIZE": "444",
             "NP_DB_REDIS_CONN_TIMEOUT": "555",
@@ -288,6 +294,7 @@ class TestEnvironConfigFactory:
         assert config.jobs.deletion_delay_s == 3600
         assert config.jobs.deletion_delay == timedelta(seconds=3600)
         assert config.jobs.orphaned_job_owner == "servicename"
+        assert config.jobs.jobs_pod_toleration_key == "jobs-pod-toleration-key"
 
         assert config.notifications.url == URL("http://notifications:8080")
         assert config.notifications.token == "token"
@@ -306,6 +313,7 @@ class TestEnvironConfigFactory:
         assert cluster.orchestrator.jobs_ingress_oauth_url == URL(
             "http://neu.ro/oauth/authorize"
         )
+        assert cluster.orchestrator.jobs_pod_toleration_key == "jobs-pod-toleration-key"
         assert cluster.orchestrator.is_http_ingress_secure
         assert cluster.orchestrator.jobs_domain_name_template == "{job_id}.jobs.domain"
         assert cluster.orchestrator.ssh_auth_domain_name == "ssh-auth.domain"


### PR DESCRIPTION
Exposes configuration key `"platform.neuromation.io/job"`, the key of job's pod toleration implemented in https://github.com/neuromation/platform-api/pull/863
