### PR TITLE
Return the 400 code when create a job with missing cluster name.

### DIFF
--- a/platform_api/api.py
+++ b/platform_api/api.py
@@ -10,7 +10,7 @@ from neuro_auth_client import AuthClient, Permission
 from neuro_auth_client.security import AuthScheme, setup_security
 from notifications_client import Client as NotificationsClient
 
-from .cluster import Cluster, ClusterConfig, ClusterRegistry
+from .cluster import Cluster, ClusterConfig, ClusterNotFound, ClusterRegistry
 from .config import Config
 from .config_factory import EnvironConfigFactory
 from .handlers import JobsHandler
@@ -147,6 +147,11 @@ async def handle_exceptions(
             payload, status=aiohttp.web.HTTPBadRequest.status_code
         )
     except JobsServiceException as e:
+        payload = {"error": str(e)}
+        return aiohttp.web.json_response(
+            payload, status=aiohttp.web.HTTPBadRequest.status_code
+        )
+    except ClusterNotFound as e:
         payload = {"error": str(e)}
         return aiohttp.web.json_response(
             payload, status=aiohttp.web.HTTPBadRequest.status_code

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -9,7 +9,6 @@ from aiohttp.web import (
     HTTPBadRequest,
     HTTPConflict,
     HTTPForbidden,
-    HTTPInternalServerError,
     HTTPNoContent,
     HTTPOk,
     HTTPUnauthorized,
@@ -472,16 +471,9 @@ class TestJobs:
         job_submit["name"] = job_name
         user = regular_user_with_missing_cluster_name
         async with client.post(url, headers=user.headers, json=job_submit) as response:
-            assert (
-                response.status == HTTPInternalServerError.status_code
-            ), await response.text()
+            assert response.status == HTTPBadRequest.status_code, await response.text()
             payload = await response.json()
-            e = (
-                f"Unexpected exception ClusterNotFound: "
-                f"Cluster '{user.cluster_name}' not found. "
-                f"Path with query: /api/v1/jobs."
-            )
-            assert payload == {"error": e}
+            assert payload == {"error": f"Cluster '{user.cluster_name}' not found"}
 
     @pytest.mark.asyncio
     async def test_create_job(


### PR DESCRIPTION
Previously the 500 code was returned.
