### PR TITLE
Fix enforcer: close aiohttp session

### DIFF
--- a/platform_api/orchestrator/job_policy_enforcer.py
+++ b/platform_api/orchestrator/job_policy_enforcer.py
@@ -52,8 +52,6 @@ class AbstractPlatformApiClient:
     async def __aexit__(self, *args: Any) -> None:
         pass
 
-    # TODO(artem) when moved to a separate microservice, add `ping()`
-
     @abc.abstractmethod
     async def get_non_terminated_jobs(self) -> List[JobInfo]:
         pass
@@ -241,17 +239,14 @@ class JobPolicyEnforcePoller:
         self._task.cancel()
 
     async def _run(self) -> None:
-        try:
-            while True:
-                start = self._loop.time()
-                await self._run_once()
-                elapsed = self._loop.time() - start
-                delay = self._config.interval_sec - elapsed
-                if delay < 0:
-                    delay = 0
-                await asyncio.sleep(delay)
-        except asyncio.CancelledError:
-            logger.info("Enforcer loop cancelled")
+        while True:
+            start = self._loop.time()
+            await self._run_once()
+            elapsed = self._loop.time() - start
+            delay = self._config.interval_sec - elapsed
+            if delay < 0:
+                delay = 0
+            await asyncio.sleep(delay)
 
     async def _run_once(self) -> None:
         try:

--- a/tests/unit/test_job_policy_enforcer.py
+++ b/tests/unit/test_job_policy_enforcer.py
@@ -487,7 +487,7 @@ class TestRealJobPolicyEnforcerClientWrapper:
             URL(f"{mock_api.endpoint}/wrong/base/path"), "token"
         )
         async with PlatformApiClient(wrong_config) as client:
-            with pytest.raises(ClientResponseError, match="Not Found"):
+            with pytest.raises(ClientResponseError, match="404, message='Not Found'"):
                 await client.get_non_terminated_jobs()
 
     @pytest.mark.asyncio
@@ -496,7 +496,7 @@ class TestRealJobPolicyEnforcerClientWrapper:
             URL(f"{mock_api.endpoint}/wrong/base/path"), "token"
         )
         client = PlatformApiClient(wrong_config)
-        with pytest.raises(ClientResponseError, match="Not Found"):
+        with pytest.raises(ClientResponseError, match="404, message='Not Found"):
             async with QuotaEnforcer(client) as enforcer:
                 await enforcer.enforce()
 


### PR DESCRIPTION
1. Add `__aenter__`, `__aexit__` methods for both `AbstractPlatformApiClient` and its implementations (as direct wrappers of `aiohttp.ClientSession`) and `JobPolicyEnforcer` and its implementations (as direct wrappers of `AbstractPlatformApiClient`) -- fixes https://github.com/neuromation/platform-api/issues/972

2. Await enforcer's task when it's cancelled to emulate graceful shutdown (thus remove messages: `Task was destroyed but it is pending!`)

3. Add regression tests for `AbstractPlatformApiClient` and `JobPolicyEnforcer` that fix proper usage of these classes (on initialization) + add test that illustrates enforcer's behaviour if `platform-api` is unavailable (404)