### PR TITLE
Fix enforcer: graceful shutdown

### DIFF
--- a/platform_api/orchestrator/job_policy_enforcer.py
+++ b/platform_api/orchestrator/job_policy_enforcer.py
@@ -195,8 +195,9 @@ class JobPolicyEnforcePoller:
         await self.stop()
 
     async def _init_task(self) -> None:
-        assert not self._is_active
-        assert not self._task
+        if self._is_active:
+            raise RuntimeError("Concurrent usage of enforce poller not allowed")
+        assert self._task is None
 
         self._is_active = self._loop.create_future()
         self._task = asyncio.ensure_future(self._run())


### PR DESCRIPTION
make `JobPolicyEnforcePoller` back to be similar to `JobsPoller` so that the polling task is not cancelled, but the shutdown is made gracefully via a future.

Fixes part 2 in https://github.com/neuromation/platform-api/issues/972