### PR TITLE
Refactor job request builder.

### DIFF
--- a/platform_api/handlers/job_request_builder.py
+++ b/platform_api/handlers/job_request_builder.py
@@ -1,5 +1,5 @@
 from pathlib import PurePath
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
 from platform_api.cluster_config import StorageConfig
 from platform_api.orchestrator.job_request import (
@@ -12,149 +12,74 @@ from platform_api.orchestrator.job_request import (
 )
 
 
-class ContainerBuilder:
-    def __init__(self, *, storage_config: StorageConfig) -> None:
-        self._storage_config = storage_config
-
-        self._image: str = ""
-        self._entrypoint: Optional[str] = None
-        self._command: Optional[str] = None
-        self._env: Dict[str, str] = {}
-        self._resources: Optional[ContainerResources] = None
-        self._volumes: List[ContainerVolume] = []
-        self._http_server: Optional[ContainerHTTPServer] = None
-        self._ssh_server: Optional[ContainerSSHServer] = None
-
-    def set_image(self, image: str) -> "ContainerBuilder":
-        self._image = image
-        return self
-
-    def set_entrypoint(self, entrypoint: str) -> "ContainerBuilder":
-        self._entrypoint = entrypoint
-        return self
-
-    def set_command(self, command: str) -> "ContainerBuilder":
-        self._command = command
-        return self
-
-    def add_env(self, name: str, value: str) -> "ContainerBuilder":
-        return self.update_env({name: value})
-
-    def update_env(self, env: Dict[str, str]) -> "ContainerBuilder":
-        self._env.update(env)
-        return self
-
-    def add_volume(self, volume: ContainerVolume) -> "ContainerBuilder":
-        self._volumes.append(volume)
-        return self
-
-    def set_resources(self, resources: ContainerResources) -> "ContainerBuilder":
-        self._resources = resources
-        return self
-
-    def set_http_server(self, http_server: ContainerHTTPServer) -> "ContainerBuilder":
-        self._http_server = http_server
-        return self
-
-    def set_ssh_server(self, ssh_server: ContainerSSHServer) -> "ContainerBuilder":
-        self._ssh_server = ssh_server
-        return self
-
-    @classmethod
-    def from_container_payload(
-        cls,
-        payload: Dict[str, Any],
-        *,
-        storage_config: StorageConfig,
-        cluster_name: str
-    ) -> "ContainerBuilder":
-        builder = cls(storage_config=storage_config)
-        builder.set_image(payload["image"])
-        if "entrypoint" in payload:
-            builder.set_entrypoint(payload["entrypoint"])
-        if "command" in payload:
-            builder.set_command(payload["command"])
-        builder.update_env(payload.get("env", {}))
-
-        builder.set_resources(cls.create_resources_from_payload(payload["resources"]))
-
-        http = payload.get("http", {})
-        if "port" in http:
-            http_server = ContainerHTTPServer(
-                port=http["port"],
-                health_check_path=http.get(
-                    "health_check_path", ContainerHTTPServer.health_check_path
-                ),
-                requires_auth=http.get(
-                    "requires_auth", ContainerHTTPServer.requires_auth
-                ),
-            )
-            builder.set_http_server(http_server)
-
-        ssh = payload.get("ssh", {})
-        if "port" in ssh:
-            ssh_server = ContainerSSHServer(ssh["port"])
-            builder.set_ssh_server(ssh_server)
-
-        for volume_payload in payload.get("volumes", []):
-            volume = cls.create_volume_from_payload(
-                volume_payload, storage_config=storage_config, cluster_name=cluster_name
-            )
-            builder.add_volume(volume)
-
-        return builder
-
-    @classmethod
-    def create_resources_from_payload(
-        cls, payload: Dict[str, Any]
-    ) -> ContainerResources:
-        tpu = None
-        if payload.get("tpu"):
-            tpu = cls.create_tpu_resource_from_payload(payload["tpu"])
-        return ContainerResources(
-            cpu=payload["cpu"],
-            memory_mb=payload["memory_mb"],
-            gpu=payload.get("gpu"),
-            gpu_model_id=payload.get("gpu_model"),
-            shm=payload.get("shm"),
-            tpu=tpu,
+def create_container_from_payload(
+    payload: Dict[str, Any], *, storage_config: StorageConfig, cluster_name: str
+) -> Container:
+    http_server = None
+    http = payload.get("http", {})
+    if "port" in http:
+        http_server = ContainerHTTPServer(
+            port=http["port"],
+            health_check_path=http.get(
+                "health_check_path", ContainerHTTPServer.health_check_path
+            ),
+            requires_auth=http.get("requires_auth", ContainerHTTPServer.requires_auth),
         )
 
-    @classmethod
-    def create_tpu_resource_from_payload(
-        self, payload: Dict[str, Any]
-    ) -> ContainerTPUResource:
-        return ContainerTPUResource(
-            type=payload["type"], software_version=payload["software_version"]
-        )
+    ssh_server = None
+    ssh = payload.get("ssh", {})
+    if "port" in ssh:
+        ssh_server = ContainerSSHServer(ssh["port"])
 
-    @classmethod
-    def create_volume_from_payload(
-        cls,
-        payload: Dict[str, Any],
-        *,
-        storage_config: StorageConfig,
-        cluster_name: str
-    ) -> ContainerVolume:
-        dst_path = PurePath(payload["dst_path"])
-        return ContainerVolume.create(
-            payload["src_storage_uri"],
-            src_mount_path=storage_config.host_mount_path,
-            dst_mount_path=dst_path,
-            extend_dst_mount_path=False,
-            read_only=bool(payload.get("read_only")),
-            scheme=storage_config.uri_scheme,
-            cluster_name=cluster_name,
+    volumes = []
+    for volume_payload in payload.get("volumes", ()):
+        volume = create_volume_from_payload(
+            volume_payload, storage_config=storage_config, cluster_name=cluster_name
         )
+        volumes.append(volume)
 
-    def build(self) -> Container:
-        return Container(
-            image=self._image,
-            entrypoint=self._entrypoint,
-            command=self._command,
-            env=self._env,
-            volumes=self._volumes,
-            resources=self._resources,  # type: ignore
-            http_server=self._http_server,
-            ssh_server=self._ssh_server,
-        )
+    return Container(
+        image=payload["image"],
+        entrypoint=payload.get("entrypoint"),
+        command=payload.get("command"),
+        env=payload.get("env", {}),
+        volumes=volumes,
+        resources=create_resources_from_payload(payload["resources"]),
+        http_server=http_server,
+        ssh_server=ssh_server,
+    )
+
+
+def create_resources_from_payload(payload: Dict[str, Any]) -> ContainerResources:
+    tpu = None
+    if "tpu" in payload:
+        tpu = create_tpu_resource_from_payload(payload["tpu"])
+    return ContainerResources(
+        cpu=payload["cpu"],
+        memory_mb=payload["memory_mb"],
+        gpu=payload.get("gpu"),
+        gpu_model_id=payload.get("gpu_model"),
+        shm=payload.get("shm"),
+        tpu=tpu,
+    )
+
+
+def create_tpu_resource_from_payload(payload: Dict[str, Any]) -> ContainerTPUResource:
+    return ContainerTPUResource(
+        type=payload["type"], software_version=payload["software_version"]
+    )
+
+
+def create_volume_from_payload(
+    payload: Dict[str, Any], *, storage_config: StorageConfig, cluster_name: str
+) -> ContainerVolume:
+    dst_path = PurePath(payload["dst_path"])
+    return ContainerVolume.create(
+        payload["src_storage_uri"],
+        src_mount_path=storage_config.host_mount_path,
+        dst_mount_path=dst_path,
+        extend_dst_mount_path=False,
+        read_only=bool(payload.get("read_only")),
+        scheme=storage_config.uri_scheme,
+        cluster_name=cluster_name,
+    )

--- a/platform_api/handlers/jobs_handler.py
+++ b/platform_api/handlers/jobs_handler.py
@@ -27,7 +27,7 @@ from platform_api.orchestrator.jobs_storage import JobFilter, JobStorageTransact
 from platform_api.resource import TPUResource
 from platform_api.user import User, authorized_user, untrusted_user
 
-from .job_request_builder import ContainerBuilder
+from .job_request_builder import create_container_from_payload
 from .validators import (
     create_cluster_name_validator,
     create_container_request_validator,
@@ -354,11 +354,11 @@ class JobsHandler:
         job_request_validator = await self._create_job_request_validator(cluster_config)
         request_payload = job_request_validator.check(request_payload)
 
-        container = ContainerBuilder.from_container_payload(
+        container = create_container_from_payload(
             request_payload["container"],
             storage_config=cluster_config.storage,
             cluster_name=cluster_name,
-        ).build()
+        )
 
         permissions = infer_permissions_from_container(
             user,

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -9,7 +9,7 @@ from neuro_auth_client.client import Quota
 from yarl import URL
 
 from platform_api.cluster_config import RegistryConfig, StorageConfig
-from platform_api.handlers.job_request_builder import ContainerBuilder
+from platform_api.handlers.job_request_builder import create_container_from_payload
 from platform_api.orchestrator.job import (
     AggregatedRunTime,
     Job,
@@ -298,9 +298,9 @@ class TestContainerBuilder:
                 }
             ],
         }
-        container = ContainerBuilder.from_container_payload(
+        container = create_container_from_payload(
             payload, storage_config=storage_config, cluster_name="test-cluster"
-        ).build()
+        )
         assert container == Container(
             image="testimage",
             entrypoint="testentrypoint",
@@ -330,9 +330,9 @@ class TestContainerBuilder:
                 "gpu_model": "gpumodel",
             },
         }
-        container = ContainerBuilder.from_container_payload(
+        container = create_container_from_payload(
             payload, storage_config=storage_config, cluster_name="test-cluster"
-        ).build()
+        )
         assert container == Container(
             image="testimage",
             resources=ContainerResources(
@@ -350,9 +350,9 @@ class TestContainerBuilder:
                 "tpu": {"type": "v2-8", "software_version": "1.14"},
             },
         }
-        container = ContainerBuilder.from_container_payload(
+        container = create_container_from_payload(
             payload, storage_config=storage_config, cluster_name="test-cluster"
-        ).build()
+        )
         assert container == Container(
             image="testimage",
             resources=ContainerResources(
@@ -379,9 +379,9 @@ class TestContainerBuilder:
                 }
             ],
         }
-        container = ContainerBuilder.from_container_payload(
+        container = create_container_from_payload(
             payload, storage_config=storage_config, cluster_name="test-cluster"
-        ).build()
+        )
         assert container == Container(
             image="testimage",
             command="testcommand",
@@ -415,9 +415,9 @@ class TestContainerBuilder:
                 }
             ],
         }
-        container = ContainerBuilder.from_container_payload(
+        container = create_container_from_payload(
             payload, storage_config=storage_config, cluster_name="test-cluster"
-        ).build()
+        )
         assert container == Container(
             image="testimage",
             command="testcommand",


### PR DESCRIPTION
Convert a builder class to a factory method. Get rid of multiple setters.

It will require less boilerplate code when extend.