### PR TITLE
Fix job filtering by nonexisting name and no owners

### DIFF
--- a/platform_api/orchestrator/jobs_storage.py
+++ b/platform_api/orchestrator/jobs_storage.py
@@ -485,6 +485,8 @@ class RedisJobsStorage(JobsStorage):
                     "*", self._glob_escape(name)
                 )
                 owner_keys = await self._client.keys(match)
+                if not owner_keys:
+                    return []
         else:
             owner_keys = [
                 self._generate_jobs_owner_index_key(owner) for owner in owners


### PR DESCRIPTION
If there is no matching `(owner, name)` pair for the specified `name`, the `name` parameter was ignored. This caused to output multiple jobs ignoring names and the failure of the client E2E tests.