### PR TITLE
Use ISCAN instead of KEYS in Redis

### DIFF
--- a/platform_api/orchestrator/jobs_storage.py
+++ b/platform_api/orchestrator/jobs_storage.py
@@ -478,7 +478,7 @@ class RedisJobsStorage(JobsStorage):
                 match = self._generate_jobs_name_index_zset_key(
                     "*", self._glob_escape(name)
                 )
-                owner_keys = [key async for key in self._client.iscan(match)]
+                owner_keys = [key async for key in self._client.iscan(match=match)]
                 if not owner_keys:
                     return []
         else:


### PR DESCRIPTION
The latter locks a DB.

Suggested by @tvoinarovskyi.

