### PR TITLE
Prevent job names started with job-

### DIFF
--- a/platform_api/orchestrator/jobs_service.py
+++ b/platform_api/orchestrator/jobs_service.py
@@ -258,6 +258,10 @@ class JobsService:
             user_cluster = user.clusters[0]
         cluster_name = user_cluster.name
 
+        if job_name is not None and job_name.startswith("job-"):
+            raise JobsServiceException(
+                "Failed to create job: job name cannot start with 'job-' prefix."
+            )
         try:
             await self._raise_for_run_time_quota(
                 user,

--- a/tests/unit/test_job_service.py
+++ b/tests/unit/test_job_service.py
@@ -1293,3 +1293,17 @@ class TestJobServiceNotification:
         )
 
         assert notifications == mock_notifications_client.sent_notifications
+
+    @pytest.mark.asyncio
+    async def test_create_job_bad_name(
+        self, jobs_service: JobsService, mock_job_request: JobRequest
+    ) -> None:
+        user = User(cluster_name="test-cluster", name="testuser", token="")
+        with pytest.raises(JobsServiceException) as cm:
+            await jobs_service.create_job(
+                job_request=mock_job_request, user=user, job_name="job-name"
+            )
+        assert (
+            str(cm.value)
+            == "Failed to create job: job name cannot start with 'job-' prefix."
+        )


### PR DESCRIPTION
It prevents conflicts between `job-0445489a-b773-47a1-8bc4-98f7c835f7af` and `job-my-name`.