### PR TITLE
Remove code for revoking legacy permissions in tests.

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,7 +1,7 @@
 import os
 import time
 from dataclasses import dataclass
-from typing import Any, AsyncIterator, Awaitable, Callable, Optional
+from typing import AsyncIterator, Awaitable, Callable, Optional
 
 import aiohttp
 import pytest

--- a/tests/integration/auth.py
+++ b/tests/integration/auth.py
@@ -1,7 +1,6 @@
 import asyncio
 from dataclasses import dataclass
 from typing import (
-    Any,
     AsyncGenerator,
     AsyncIterator,
     Awaitable,


### PR DESCRIPTION
Currently tests are failed because new users no longer have legacy permissions.