### PR TITLE
allow ssh-auth service to work as Nodeport or LoadBalancer

### DIFF
--- a/deploy/ssh_auth/templates/ssh.gke.yml
+++ b/deploy/ssh_auth/templates/ssh.gke.yml
@@ -61,23 +61,4 @@ spec:
     {{- end }}
   selector:
     service: ssh-auth
----
-{{- if .Values.NODEPORT }}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  annotations:
-    kubernetes.io/ingress.class: traefik
-  labels:
-    app: ssh-auth
-  name: ssh-auth-ingress
-spec:
-  rules:
-  - host:  {{ .Values.INGRESS_HOST }}
-    http:
-      paths:
-      - backend:
-          serviceName: ssh-auth
-          servicePort: 22
-        path: /
-{{- end }}
+

--- a/deploy/ssh_auth/values-template.yaml
+++ b/deploy/ssh_auth/values-template.yaml
@@ -4,4 +4,3 @@ NP_PLATFORM_API_URL: http://platformapi:8080/api/v1
 NP_K8S_NS: ''
 DOCKER_LOGIN_ARTIFACTORY_SECRET_NAME: "artifactory-regcred"
 NODEPORT: ''
-INGRESS_HOST: ''


### PR DESCRIPTION
allow ssh-auth to work as Nodeport + ingress . this is needed for on-prem clusters