### PR TITLE
Expose secret_env and secret_volumes attributes in job requests

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -146,6 +146,7 @@ async def regular_user_factory(
             {"uri": f"storage://{cluster_name}/{name}", "action": "manage"},
             {"uri": f"image://{cluster_name}/{name}", "action": "manage"},
             {"uri": f"job://{cluster_name}/{name}", "action": "manage"},
+            {"uri": f"secret://{cluster_name}/{name}", "action": "write"},
         ]
         async with auth_client._request(
             "POST", f"/api/v1/users/{name}/permissions", headers=headers, json=payload

--- a/tests/integration/auth.py
+++ b/tests/integration/auth.py
@@ -177,6 +177,7 @@ async def regular_user_factory(
                     {"uri": f"storage://{cluster.name}/{name}", "action": "manage"},
                     {"uri": f"image://{cluster.name}/{name}", "action": "manage"},
                     {"uri": f"job://{cluster.name}/{name}", "action": "manage"},
+                    {"uri": f"secret://{cluster.name}/{name}", "action": "write"},
                 ]
             )
         async with auth_client._request(

--- a/tests/unit/test_job_rest_validator.py
+++ b/tests/unit/test_job_rest_validator.py
@@ -440,6 +440,46 @@ class TestVolumesValidator:
             assert validator.check(value)
 
 
+class TestSecretVolumesValidator:
+    def test_valid_volumes(self) -> None:
+        value = [
+            {"src_secret_uri": "storage://test-cluster/uri1", "dst_path": "/path1"},
+            {"src_secret_uri": "storage://test-cluster/uri2", "dst_path": "/path2"},
+        ]
+        validator = create_volumes_validator(
+            uri_key="src_secret_uri",
+            has_read_only_key=False,
+            cluster_name="test-cluster",
+        )
+        assert validator.check(value)
+
+    def test_destination_paths_are_unique(self) -> None:
+        value = [
+            {"src_secret_uri": "storage://test-cluster/uri1", "dst_path": "path"},
+            {"src_secret_uri": "storage://test-cluster/uri2", "dst_path": "path"},
+        ]
+        validator = create_volumes_validator(
+            uri_key="src_secret_uri",
+            has_read_only_key=False,
+            cluster_name="test-cluster",
+        )
+        with pytest.raises(t.DataError):
+            assert validator.check(value)
+
+    def test_volumes_are_unique(self) -> None:
+        value = [
+            {"src_secret_uri": "storage://test-cluster/uri", "dst_path": "path"},
+            {"src_secret_uri": "storage://test-cluster/uri", "dst_path": "path"},
+        ]
+        validator = create_volumes_validator(
+            uri_key="src_secret_uri",
+            has_read_only_key=False,
+            cluster_name="test-cluster",
+        )
+        with pytest.raises(t.DataError):
+            assert validator.check(value)
+
+
 class TestPathUriValidator:
     def test_invalid_uri_scheme(self) -> None:
         cluster = "test-cluster"


### PR DESCRIPTION
closes https://github.com/neuromation/platform-api/issues/1231

In validators, we require:
1) secret URIs be unique across all of secret_env and secret_volumes,
2) mount points be unique across secret_volumes.

This PR contains 2 logical parts:
1. Extend internal Job representation to store secret_env and secret_volumes,
2. Extend API to accept and return these values.
Even though I consider these parts to be small enough to fit into a single PR, I can split it into 2 PRs if it's hard to review.