### PR TITLE
update port forward test

### DIFF
--- a/tests/e2e/test_port_forward.py
+++ b/tests/e2e/test_port_forward.py
@@ -274,7 +274,7 @@ async def test_port_forward_nonexposed(
                 break
         except asyncio.TimeoutError:
             break
-    with pytest.raises(aiohttp.ServerDisconnectedError):
+    with pytest.raises(aiohttp.ClientConnectionError):
         await client.get(f"http://{LOCALHOST}:{port}")
     proc.kill()
     await proc.wait()


### PR DESCRIPTION
For some reason ClientOSError("Connection reset by peer") is raised. ClientConnectionError is a base class for both of them.