### PR TITLE
Postgres try update create

### DIFF
--- a/platform_api/orchestrator/job_request.py
+++ b/platform_api/orchestrator/job_request.py
@@ -433,6 +433,10 @@ class JobStatus(str, enum.Enum):
     def values(cls) -> List[str]:
         return [item.value for item in cls]
 
+    @classmethod
+    def active_values(cls) -> List[str]:
+        return [item.value for item in cls if not item.is_finished]
+
     def __repr__(self) -> str:
         return f"JobStatus.{self.name}"
 

--- a/tests/integration/test_jobs_storage.py
+++ b/tests/integration/test_jobs_storage.py
@@ -33,7 +33,7 @@ from platform_api.orchestrator.jobs_storage.postgres import PostgresJobsStorage
 from tests.conftest import not_raises, random_str
 
 
-class TestRedisJobsStorage:
+class TestJobsStorage:
     @pytest.fixture(params=["redis", "postgres"])
     def storage(
         self, request: Any, redis_client: aioredis.Redis, postgres_pool: Pool
@@ -177,10 +177,7 @@ class TestRedisJobsStorage:
         assert job_id_last_created == job3.id
 
     @pytest.mark.asyncio
-    async def test_try_create_job__no_name__ok(
-        self, redis_client: aioredis.Redis
-    ) -> None:
-        storage = RedisJobsStorage(redis_client)
+    async def test_try_create_job__no_name__ok(self, storage: JobsStorage) -> None:
 
         pending_job = self._create_pending_job()
         async with storage.try_create_job(pending_job) as job:
@@ -200,9 +197,8 @@ class TestRedisJobsStorage:
 
     @pytest.mark.asyncio
     async def test_try_create_job__no_name__job_changed_while_creation(
-        self, redis_client: aioredis.Redis
+        self, storage: JobsStorage
     ) -> None:
-        storage = RedisJobsStorage(redis_client)
         job = self._create_pending_job()
 
         # process-1
@@ -234,9 +230,8 @@ class TestRedisJobsStorage:
 
     @pytest.mark.asyncio
     async def test_try_create_job__different_name_same_owner__ok(
-        self, redis_client: aioredis.Redis
+        self, storage: JobsStorage
     ) -> None:
-        storage = RedisJobsStorage(redis_client)
 
         owner = "test-user-1"
         job_name_1 = "some-test-job-name-1"
@@ -260,9 +255,8 @@ class TestRedisJobsStorage:
 
     @pytest.mark.asyncio
     async def test_try_create_job__same_name_different_owner__ok(
-        self, redis_client: aioredis.Redis
+        self, storage: JobsStorage
     ) -> None:
-        storage = RedisJobsStorage(redis_client)
 
         owner_1 = "test-user-1"
         job_name_1 = "some-test-job-name-1"
@@ -288,9 +282,8 @@ class TestRedisJobsStorage:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("first_job_status", [JobStatus.PENDING, JobStatus.RUNNING])
     async def test_try_create_job__same_name_with_an_active_job__conflict(
-        self, redis_client: aioredis.Redis, first_job_status: JobStatus
+        self, storage: JobsStorage, first_job_status: JobStatus
     ) -> None:
-        storage = RedisJobsStorage(redis_client)
 
         owner = "test-user"
         job_name = "some-test-job-name"
@@ -318,9 +311,8 @@ class TestRedisJobsStorage:
         "first_job_status", [JobStatus.SUCCEEDED, JobStatus.FAILED]
     )
     async def test_try_create_job__same_name_with_a_terminated_job__ok(
-        self, redis_client: aioredis.Redis, first_job_status: JobStatus
+        self, storage: JobsStorage, first_job_status: JobStatus
     ) -> None:
-        storage = RedisJobsStorage(redis_client)
         owner = "test-user"
         job_name = "some-test-job-name"
 
@@ -344,8 +336,7 @@ class TestRedisJobsStorage:
         assert job.status == JobStatus.PENDING
 
     @pytest.mark.asyncio
-    async def test_try_create_job_with_tags(self, redis_client: aioredis.Redis) -> None:
-        storage = RedisJobsStorage(redis_client)
+    async def test_try_create_job_with_tags(self, storage: JobsStorage) -> None:
 
         tags = ["tag1", "tag2"]
         job = self._create_job(tags=tags)
@@ -357,8 +348,7 @@ class TestRedisJobsStorage:
         assert result_job.tags == tags
 
     @pytest.mark.asyncio
-    async def test_get_non_existent(self, redis_client: aioredis.Redis) -> None:
-        storage = RedisJobsStorage(redis_client)
+    async def test_get_non_existent(self, storage: JobsStorage) -> None:
         with pytest.raises(JobError, match="no such job unknown"):
             await storage.get_job("unknown")
 
@@ -1301,10 +1291,7 @@ class TestRedisJobsStorage:
         assert not jobs
 
     @pytest.mark.asyncio
-    async def test_try_update_job__no_name__ok(
-        self, redis_client: aioredis.Redis
-    ) -> None:
-        storage = RedisJobsStorage(redis_client)
+    async def test_try_update_job__no_name__ok(self, storage: JobsStorage) -> None:
         pending_job = self._create_pending_job()
         await storage.set_job(pending_job)
 
@@ -1316,10 +1303,7 @@ class TestRedisJobsStorage:
         assert running_job.status == JobStatus.RUNNING
 
     @pytest.mark.asyncio
-    async def test_try_update_job__not_found(
-        self, redis_client: aioredis.Redis
-    ) -> None:
-        storage = RedisJobsStorage(redis_client)
+    async def test_try_update_job__not_found(self, storage: JobsStorage) -> None:
         pending_job = self._create_pending_job()
 
         with pytest.raises(JobError, match=f"no such job {pending_job.id}"):
@@ -1328,9 +1312,8 @@ class TestRedisJobsStorage:
 
     @pytest.mark.asyncio
     async def test_try_update_job__no_name__job_changed_while_creation(
-        self, redis_client: aioredis.Redis
+        self, storage: JobsStorage
     ) -> None:
-        storage = RedisJobsStorage(redis_client)
         job = self._create_pending_job()
         await storage.set_job(job)
 
@@ -1363,9 +1346,8 @@ class TestRedisJobsStorage:
 
     @pytest.mark.asyncio
     async def test_try_update_job__different_name_same_owner__ok(
-        self, redis_client: aioredis.Redis
+        self, storage: JobsStorage
     ) -> None:
-        storage = RedisJobsStorage(redis_client)
 
         owner = "test-user-1"
         job_name_1 = "some-test-job-name-1"
@@ -1392,9 +1374,8 @@ class TestRedisJobsStorage:
 
     @pytest.mark.asyncio
     async def test_try_update_job__same_name_different_owner__ok(
-        self, redis_client: aioredis.Redis
+        self, storage: JobsStorage
     ) -> None:
-        storage = RedisJobsStorage(redis_client)
 
         owner_1 = "test-user-1"
         owner_2 = "test-user-2"
@@ -1424,9 +1405,8 @@ class TestRedisJobsStorage:
         "first_job_status", [JobStatus.SUCCEEDED, JobStatus.FAILED]
     )
     async def test_try_update_job__same_name_with_a_terminated_job__ok(
-        self, redis_client: aioredis.Redis, first_job_status: JobStatus
+        self, storage: JobsStorage, first_job_status: JobStatus
     ) -> None:
-        storage = RedisJobsStorage(redis_client)
         owner = "test-user"
         job_name = "some-test-job-name"
 


### PR DESCRIPTION
This PR is part of https://github.com/neuromation/platform-api/issues/1285.
It adds `try_update` and `try_create` methods to `PostgresJobsStorage`. Those methods are responsible of concurrency handling in job updates.