### PR TITLE
Rs/postgres get aggregated run time

### DIFF
--- a/platform_api/orchestrator/jobs_storage/postgres.py
+++ b/platform_api/orchestrator/jobs_storage/postgres.py
@@ -23,7 +23,7 @@ from asyncpg.pool import Pool
 from asyncpg.protocol.protocol import Record
 from sqlalchemy import Boolean, Integer, and_, asc, desc, not_, or_, select
 
-from platform_api.orchestrator.job import AggregatedRunTime, JobRecord
+from platform_api.orchestrator.job import JobRecord
 from platform_api.orchestrator.job_request import JobError, JobStatus
 from platform_api.orchestrator.jobs_storage import JobFilter
 
@@ -341,11 +341,6 @@ class PostgresJobsStorage(JobsStorage):
             .order_by(desc(sub_query.c.created_at), sub_query.c.index)
         )
         return [record[0] for record in await self._fetch(query)]
-
-    async def get_aggregated_run_time_by_clusters(
-        self, job_filter: JobFilter
-    ) -> Dict[str, AggregatedRunTime]:
-        raise NotImplementedError
 
 
 class JobFilterClauseBuilder:

--- a/platform_api/orchestrator/jobs_storage/redis.py
+++ b/platform_api/orchestrator/jobs_storage/redis.py
@@ -454,31 +454,7 @@ class RedisJobsStorage(JobsStorage):
     async def get_aggregated_run_time_by_clusters(
         self, job_filter: JobFilter
     ) -> Dict[str, AggregatedRunTime]:
-        zero_run_time = (timedelta(), timedelta())
-        aggregated_run_times: Dict[str, Tuple[timedelta, timedelta]] = {}
-        async for job in self.iter_all_jobs(job_filter):
-            gpu_run_time, non_gpu_run_time = aggregated_run_times.get(
-                job.cluster_name, zero_run_time
-            )
-            if job.has_gpu:
-                gpu_run_time += job.get_run_time()
-            else:
-                non_gpu_run_time += job.get_run_time()
-            aggregated_run_times[job.cluster_name] = (
-                gpu_run_time,
-                non_gpu_run_time,
-            )
-
-        return {
-            cluster_name: AggregatedRunTime(
-                total_gpu_run_time_delta=gpu_run_time,
-                total_non_gpu_run_time_delta=non_gpu_run_time,
-            )
-            for cluster_name, (
-                gpu_run_time,
-                non_gpu_run_time,
-            ) in aggregated_run_times.items()
-        }
+        return await super().get_aggregated_run_time_by_clusters(job_filter)
 
     async def migrate(self) -> bool:
         version = int(await self._client.get("version") or "0")

--- a/tests/integration/test_jobs_storage.py
+++ b/tests/integration/test_jobs_storage.py
@@ -1555,9 +1555,7 @@ class TestJobsStorage:
             convert(URL("image://alice"), "test-cluster")
 
     @pytest.mark.asyncio
-    async def test_get_aggregated_run_time_for_user(
-        self, redis_client: aioredis.Redis
-    ) -> None:
+    async def test_get_aggregated_run_time_for_user(self, storage: JobsStorage) -> None:
         test_started_at = current_datetime_factory()
         owner = f"test-user-{random_str()}"
 
@@ -1610,7 +1608,6 @@ class TestJobsStorage:
             create_job(cluster_name="test-cluster2", with_gpu=False, finished=True),
             create_job(cluster_name="test-cluster2", with_gpu=False, finished=True),
         ]
-        storage = RedisJobsStorage(redis_client)
         for job in jobs_with_gpu + jobs_no_gpu:
             async with storage.try_create_job(job):
                 pass


### PR DESCRIPTION
This PR is part of https://github.com/neuromation/platform-api/issues/1285.
It moves `get_aggregated_run_time_by_clusters` method to `JobsStorage(ABC)` as it is same for in memory and redis storages.