### PR TITLE
Add logout_url to /config response

### DIFF
--- a/platform_api/api.py
+++ b/platform_api/api.py
@@ -109,6 +109,7 @@ class ApiHandler:
         if self._config.oauth:
             data["auth_url"] = str(self._config.oauth.auth_url)
             data["token_url"] = str(self._config.oauth.token_url)
+            data["logout_url"] = str(self._config.oauth.logout_url)
             data["client_id"] = self._config.oauth.client_id
             data["audience"] = self._config.oauth.audience
             data["callback_urls"] = [str(u) for u in self._config.oauth.callback_urls]

--- a/platform_api/config.py
+++ b/platform_api/config.py
@@ -52,6 +52,10 @@ class OAuthConfig:
     def token_url(self) -> URL:
         return self.base_url / "oauth/token"
 
+    @property
+    def logout_url(self) -> URL:
+        return self.base_url / "v2/logout"
+
 
 @dataclass(frozen=True)
 class DatabaseConfig:

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -324,6 +324,7 @@ class TestApi:
             expected_payload: Dict[str, Any] = {
                 "auth_url": "https://platform-auth0-url/authorize",
                 "token_url": "https://platform-auth0-url/oauth/token",
+                "logout_url": "https://platform-auth0-url/v2/logout",
                 "client_id": "client_id",
                 "audience": "https://platform-dev-url",
                 "success_redirect_url": "https://platform-default-url",


### PR DESCRIPTION
This allows to implement https://github.com/neuromation/platform-client-python/issues/680 on the client
Auth0 about added endpoint: https://auth0.com/docs/api/authentication?http#logout