### PR TITLE
Fix alembic data migration

### DIFF
--- a/alembic/versions/81675d81a9c7_copy_data_from_redis.py
+++ b/alembic/versions/81675d81a9c7_copy_data_from_redis.py
@@ -6,13 +6,13 @@ Create Date: 2020-09-11 18:19:36.310016
 
 """
 import asyncio
-from typing import Tuple
 
-from alembic import context
+import sqlalchemy as sa
+import sqlalchemy.dialects.postgresql as sapg
+from alembic import context, op
 
-from platform_api.config import PostgresConfig
-from platform_api.orchestrator.jobs_storage import PostgresJobsStorage, RedisJobsStorage
-from platform_api.postgres import create_postgres_pool
+from platform_api.orchestrator.job import JobRecord
+from platform_api.orchestrator.jobs_storage import RedisJobsStorage
 from platform_api.redis import RedisConfig, create_redis_client
 
 
@@ -24,46 +24,81 @@ branch_labels = None
 depends_on = None
 
 
-async def move_redis_to_postgres(
-    redis_config: RedisConfig, postgres_config: PostgresConfig
-):
-    async with create_redis_client(redis_config) as redis, create_postgres_pool(
-        postgres_config
-    ) as postgres:
+def get_job_table():
+    metadata = sa.MetaData()
+    return sa.Table(
+        "jobs",
+        metadata,
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("owner", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=True),
+        sa.Column("cluster_name", sa.String(), nullable=False),
+        sa.Column("tags", sapg.JSONB(), nullable=True),
+        # Denormalized fields for optimized access/unique constrains checks
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column(
+            "created_at", sapg.TIMESTAMP(timezone=True, precision=6), nullable=False
+        ),
+        sa.Column(
+            "finished_at", sapg.TIMESTAMP(timezone=True, precision=6), nullable=True
+        ),
+        # All other fields
+        sa.Column("payload", sapg.JSONB(), nullable=False),
+    )
+
+
+async def move_redis_to_postgres(redis_config: RedisConfig):
+    async with create_redis_client(redis_config) as redis:
         redis_storage = RedisJobsStorage(redis)
-        postgres_storage = PostgresJobsStorage(postgres)
+        table = get_job_table()
+
         async for job in redis_storage.iter_all_jobs():
-            await postgres_storage.set_job(job)
+            payload = job.to_primitive()
+            values = {
+                "id": payload.pop("id"),
+                "owner": payload.pop("owner"),
+                "name": payload.pop("name", None),
+                "cluster_name": payload.pop("cluster_name"),
+                "tags": payload.pop("tags", None),
+                "status": job.status_history.current.status,
+                "created_at": job.status_history.created_at,
+                "finished_at": job.status_history.finished_at,
+                "payload": payload,
+            }
+            op.bulk_insert(table, [values])
 
 
-async def move_postgres_to_redis(
-    redis_config: RedisConfig, postgres_config: PostgresConfig
-):
-    async with create_redis_client(redis_config) as redis, create_postgres_pool(
-        postgres_config
-    ) as postgres:
+async def move_postgres_to_redis(redis_config: RedisConfig):
+    async with create_redis_client(redis_config) as redis:
         redis_storage = RedisJobsStorage(redis)
-        postgres_storage = PostgresJobsStorage(postgres)
-        async for job in postgres_storage.iter_all_jobs():
+        conn = op.get_bind()
+        res = conn.execute("select * from jobs")
+        results = res.fetchall()
+        for result in results:
+            record = dict(result.items())
+            payload = record["payload"]
+            payload["id"] = record["id"]
+            payload["owner"] = record["owner"]
+            payload["name"] = record["name"]
+            payload["cluster_name"] = record["cluster_name"]
+            if record["tags"] is not None:
+                payload["tags"] = record["tags"]
+            job = JobRecord.from_primitive(payload)
             await redis_storage.set_job(job)
 
 
-def _make_configs() -> Tuple[RedisConfig, PostgresConfig]:
-    # We need this to be able to run tests properly
+def _make_redis_config() -> RedisConfig:
+    # We need this to go through context.config be able to run tests properly
     redis_config = RedisConfig(uri=context.config.get_main_option("redis_url"))
-    postgres_config = PostgresConfig(
-        postgres_dsn=context.config.get_main_option("sqlalchemy.url"),
-        alembic=None,  # noqa
-    )
     assert redis_config.uri, (
         "Data migration from redis to postgres cannot run " "without redis url set"
     )
-    return redis_config, postgres_config
+    return redis_config
 
 
 def upgrade():
-    asyncio.run(move_redis_to_postgres(*_make_configs()))
+    asyncio.run(move_redis_to_postgres(_make_redis_config()))
 
 
 def downgrade():
-    asyncio.run(move_redis_to_postgres(*_make_configs()))
+    asyncio.run(move_postgres_to_redis(_make_redis_config()))

--- a/platform_api/orchestrator/jobs_storage/postgres.py
+++ b/platform_api/orchestrator/jobs_storage/postgres.py
@@ -113,11 +113,6 @@ class PostgresJobsStorage(JobsStorage):
             "finished_at": job.status_history.finished_at,
             "payload": payload,
         }
-        values = job.to_primitive()
-        values["status"] = job.status_history.current.status
-        values["created_at"] = job.status_history.created_at
-        values["finished_at"] = job.status_history.finished_at
-        return values
 
     def _record_to_job(self, record: Record) -> JobRecord:
         payload = json.loads(record["payload"])

--- a/tests/integration/postgres.py
+++ b/tests/integration/postgres.py
@@ -15,7 +15,7 @@ from platform_api.redis import RedisConfig
 
 
 @pytest.fixture(scope="session")
-async def _postgres_dsn(
+async def postgres_dsn(
     docker: aiodocker.Docker, reuse_docker: bool
 ) -> AsyncIterator[str]:
     image_name = "postgres:11.3"
@@ -80,12 +80,12 @@ async def _wait_for_postgres_server(
 
 @pytest.fixture
 async def postgres_config(
-    _postgres_dsn: str, redis_config: RedisConfig
+    postgres_dsn: str, redis_config: RedisConfig
 ) -> AsyncIterator[PostgresConfig]:
 
     db_config = PostgresConfig(
-        postgres_dsn=_postgres_dsn,
-        alembic=EnvironConfigFactory().create_alembic(_postgres_dsn, redis_config.uri),
+        postgres_dsn=postgres_dsn,
+        alembic=EnvironConfigFactory().create_alembic(postgres_dsn, redis_config.uri),
     )
     migration_runner = MigrationRunner(db_config)
     await migration_runner.upgrade()


### PR DESCRIPTION
Unfortunately, it is wrong to create new db connections inside alembic migration - they will not be able to see changes from previous migration in that batch, and in general it isn't safe. This PR uses alembics `op` to migrate data. Also I added tests to make sure it works properly.