### PR TITLE
Make postgres use materialized index

### DIFF
--- a/alembic/versions/4d851c8afb11_change_materialized_index.py
+++ b/alembic/versions/4d851c8afb11_change_materialized_index.py
@@ -1,0 +1,36 @@
+"""change materialized index
+
+Revision ID: 4d851c8afb11
+Revises: bff7b93a59c2
+Create Date: 2020-11-27 16:33:40.235283
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "4d851c8afb11"
+down_revision = "bff7b93a59c2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_index("jobs_materialized_index", table_name="jobs")
+    op.create_index(
+        "jobs_materialized_index",
+        "jobs",
+        [sa.text("(((payload ->> 'materialized'::text))::boolean)")],
+    )
+    op.execute("ANALYZE jobs;")  # Collect statistics.
+
+
+def downgrade():
+    op.drop_index("jobs_materialized_index", table_name="jobs")
+    op.create_index(
+        "jobs_materialized_index",
+        "jobs",
+        [sa.text("(((payload ->> 'materialized'::text))::boolean)")],
+        postgresql_where=sa.text("(((payload ->> 'materialized'::text))::boolean)"),
+    )


### PR DESCRIPTION
Because “materialised” a property inside jsonb columnd, there is no
statistics for it. By creating full-table functional index we make
postgres collect statistics for it.