### PR TITLE
Add finished at index

### DIFF
--- a/alembic/versions/331ab0d09462_finished_at_index.py
+++ b/alembic/versions/331ab0d09462_finished_at_index.py
@@ -1,0 +1,27 @@
+"""finished_at_index
+
+Revision ID: 331ab0d09462
+Revises: 68197d86eb6f
+Create Date: 2020-12-24 16:15:44.297184
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "331ab0d09462"
+down_revision = "68197d86eb6f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "jobs_finished_at_index",
+        "jobs",
+        ["finished_at"],
+    )
+
+
+def downgrade():
+    op.drop_index("jobs_finished_at_index", table_name="jobs")


### PR DESCRIPTION
This index is used when the system updates entries in `jobs_runtime_cache` table.