### PR TITLE
add nodes watcher/handler

### DIFF
--- a/platform_api/orchestrator/base.py
+++ b/platform_api/orchestrator/base.py
@@ -24,10 +24,6 @@ class Orchestrator(ABC):
         pass
 
     @abstractmethod
-    async def preempt_idle_jobs(self, jobs_to_schedule: list[Job]) -> bool:
-        pass
-
-    @abstractmethod
     async def get_missing_secrets(
         self, secret_path: str, secret_names: list[str]
     ) -> list[str]:

--- a/platform_api/orchestrator/kube_client.py
+++ b/platform_api/orchestrator/kube_client.py
@@ -1069,10 +1069,8 @@ class PodDescriptor:
     def env_list(self) -> list[dict[str, str]]:
         return [dict(name=name, value=value) for name, value in self.env.items()]
 
-    def can_be_scheduled(self, node_name: str, node_labels: dict[str, str]) -> bool:
+    def can_be_scheduled(self, node_labels: dict[str, str]) -> bool:
         affinities: list[NodeAffinity] = []
-        if self.node_name:
-            return self.node_name == node_name
         if self.node_selector:
             requirements = [
                 NodeSelectorRequirement.create_in(k, v)

--- a/platform_api/orchestrator/kube_client.py
+++ b/platform_api/orchestrator/kube_client.py
@@ -1069,8 +1069,10 @@ class PodDescriptor:
     def env_list(self) -> list[dict[str, str]]:
         return [dict(name=name, value=value) for name, value in self.env.items()]
 
-    def can_be_scheduled(self, node_labels: dict[str, str]) -> bool:
+    def can_be_scheduled(self, node_name: str, node_labels: dict[str, str]) -> bool:
         affinities: list[NodeAffinity] = []
+        if self.node_name:
+            return self.node_name == node_name
         if self.node_selector:
             requirements = [
                 NodeSelectorRequirement.create_in(k, v)
@@ -1632,6 +1634,16 @@ class NodeResources:
     def cpu_mcores(self) -> int:
         return int(self.cpu * 1000)
 
+    def are_sufficient(self, pod: PodDescriptor) -> bool:
+        r = pod.resources
+        if not r:
+            return True
+        return (
+            self.cpu_mcores >= r.cpu_mcores
+            and self.memory >= r.memory
+            and self.gpu >= (r.gpu or 0)
+        )
+
     def __add__(self, other: "NodeResources") -> "NodeResources":
         return self.__class__(
             cpu=self.cpu + other.cpu,
@@ -1650,33 +1662,102 @@ class NodeResources:
         return f"cpu={self.cpu_mcores}m, memory={self.memory}Mi, gpu={self.gpu}"
 
 
+class NodeConditionType(enum.Enum):
+    UNKNOWN = "Unknown"
+    DISK_PRESSURE = "DiskPressure"
+    MEMORY_PRESSURE = "MemoryPressure"
+    NETWORK_UNAVAILABLE = "NetworkUnavailable"
+    PID_PRESSURE = "PIDPressure"
+    READY = "Ready"
+
+    @classmethod
+    def parse(cls, value: str) -> "NodeConditionType":
+        try:
+            return cls(value)
+        except (KeyError, ValueError):
+            return cls.UNKNOWN
+
+
+@dataclass(frozen=True)
+class NodeCondition:
+    type: NodeConditionType
+    status: Optional[bool]
+    transition_time: datetime
+    message: str = ""
+    reason: str = ""
+
+    @classmethod
+    def from_primitive(cls, payload: dict[str, Any]) -> "NodeCondition":
+        return cls(
+            type=NodeConditionType.parse(payload["type"]),
+            status=cls._parse_status(payload["status"]),
+            message=payload.get("message", ""),
+            reason=payload.get("reason", ""),
+            transition_time=iso8601.parse_date(payload["lastTransitionTime"]),
+        )
+
+    @classmethod
+    def _parse_status(cls, value: str) -> Optional[bool]:
+        if value == "Unknown":
+            return None
+        elif value == "True":
+            return True
+        elif value == "False":
+            return False
+        raise ValueError(f"Invalid status {value!r}")
+
+
+@dataclass(frozen=True)
+class NodeStatus:
+    allocatable_resources: NodeResources
+    conditions: list[NodeCondition] = field(default_factory=list)
+
+    @classmethod
+    def from_primitive(cls, payload: dict[str, Any]) -> "NodeStatus":
+        return cls(
+            allocatable_resources=NodeResources.from_primitive(payload["allocatable"]),
+            conditions=[
+                NodeCondition.from_primitive(p) for p in payload.get("conditions", ())
+            ],
+        )
+
+    @property
+    def is_ready(self) -> bool:
+        for cond in self.conditions:
+            if cond.type == NodeConditionType.READY:
+                return bool(cond.status)
+        return False
+
+
 @dataclass(frozen=True)
 class Node:
     name: str
-    allocatable_resources: NodeResources = field(compare=False)
+    status: NodeStatus = field(compare=False)
     labels: dict[str, str] = field(default_factory=dict, compare=False)
 
     @classmethod
     def from_primitive(cls, payload: dict[str, Any]) -> "Node":
         metadata = payload["metadata"]
-        status = payload["status"]
         return cls(
             name=metadata["name"],
             labels=metadata.get("labels", {}),
-            allocatable_resources=NodeResources.from_primitive(status["allocatable"]),
+            status=NodeStatus.from_primitive(payload["status"]),
         )
+
+    def get_free_resources(self, resource_requests: NodeResources) -> NodeResources:
+        return self.status.allocatable_resources - resource_requests
 
 
 @dataclass(frozen=True)
-class RawPodListResult:
+class ListResult:
     resource_version: str
-    raw_pods: list[dict[str, Any]]
+    items: list[dict[str, Any]]
 
     @classmethod
-    def from_primitive(cls, payload: dict[str, Any]) -> "RawPodListResult":
+    def from_primitive(cls, payload: dict[str, Any]) -> "ListResult":
         return cls(
             resource_version=payload["metadata"]["resourceVersion"],
-            raw_pods=payload["items"],
+            items=payload["items"],
         )
 
 
@@ -1703,29 +1784,29 @@ class WatchBookmarkEvent:
 
 
 @dataclass(frozen=True)
-class PodWatchEvent:
+class WatchEvent:
     type: WatchEventType
-    raw_pod: dict[str, Any]
+    resource: dict[str, Any]
 
     @classmethod
-    def from_primitive(cls, payload: dict[str, Any]) -> "PodWatchEvent":
-        return cls(type=WatchEventType(payload["type"]), raw_pod=payload["object"])
+    def from_primitive(cls, payload: dict[str, Any]) -> "WatchEvent":
+        return cls(type=WatchEventType(payload["type"]), resource=payload["object"])
 
     @classmethod
     def is_error(cls, payload: dict[str, Any]) -> bool:
         return WatchEventType.ERROR == payload["type"].upper()
 
     @classmethod
-    def create_added(cls, raw_pod: dict[str, Any]) -> "PodWatchEvent":
-        return cls(type=WatchEventType.ADDED, raw_pod=raw_pod)
+    def create_added(cls, resource: dict[str, Any]) -> "WatchEvent":
+        return cls(type=WatchEventType.ADDED, resource=resource)
 
     @classmethod
-    def create_modified(cls, raw_pod: dict[str, Any]) -> "PodWatchEvent":
-        return cls(type=WatchEventType.MODIFIED, raw_pod=raw_pod)
+    def create_modified(cls, resource: dict[str, Any]) -> "WatchEvent":
+        return cls(type=WatchEventType.MODIFIED, resource=resource)
 
     @classmethod
-    def create_deleted(cls, raw_pod: dict[str, Any]) -> "PodWatchEvent":
-        return cls(type=WatchEventType.DELETED, raw_pod=raw_pod)
+    def create_deleted(cls, resource: dict[str, Any]) -> "WatchEvent":
+        return cls(type=WatchEventType.DELETED, resource=resource)
 
 
 class KubeClient:
@@ -1950,6 +2031,31 @@ class KubeClient:
             logging.debug("k8s response payload: %s", payload)
             return payload
 
+    async def _watch(
+        self,
+        url: str,
+        params: Optional[dict[str, str]] = None,
+        resource_version: Optional[str] = None,
+    ) -> AsyncIterator[Union[WatchEvent, WatchBookmarkEvent]]:
+        params = params or {}
+        params.update(watch="true", allowWatchBookmarks="true")
+        if resource_version:
+            params["resourceVersion"] = resource_version
+        assert self._client
+        async with self._client.get(
+            url, params=params, timeout=aiohttp.ClientTimeout()
+        ) as response:
+            if response.status == 410:
+                raise ResourceGoneException
+            async for line in response.content:
+                payload = json.loads(line)
+                if WatchEvent.is_error(payload):
+                    self._check_status_payload(payload["object"])
+                if WatchBookmarkEvent.is_bookmark(payload):
+                    yield WatchBookmarkEvent.from_primitive(payload)
+                else:
+                    yield WatchEvent.from_primitive(payload)
+
     async def get_api_resource(self, group_version: str) -> APIResource:
         url = f"{self._base_url}/apis/{group_version}"
         payload = await self._request(method="GET", url=url, raise_for_status=True)
@@ -2017,6 +2123,32 @@ class KubeClient:
         assert payload["kind"] == "Node"
         return Node.from_primitive(payload)
 
+    async def get_raw_nodes(
+        self, labels: Optional[dict[str, str]] = None
+    ) -> ListResult:
+        params: dict[str, str] = {}
+        if labels:
+            params["labelSelector"] = ",".join(
+                "=".join(item) for item in labels.items()
+            )
+        payload = await self._request(method="GET", url=self._nodes_url, params=params)
+        self._check_status_payload(payload)
+        assert payload["kind"] == "NodeList"
+        return ListResult.from_primitive(payload)
+
+    async def watch_nodes(
+        self,
+        labels: Optional[dict[str, str]] = None,
+        resource_version: Optional[str] = None,
+    ) -> AsyncIterator[Union[WatchEvent, WatchBookmarkEvent]]:
+        params: dict[str, str] = {}
+        if labels:
+            params["labelSelector"] = ",".join(
+                "=".join(item) for item in labels.items()
+            )
+        async for event in self._watch(self._nodes_url, params, resource_version):
+            yield event
+
     async def create_pod(self, descriptor: PodDescriptor) -> PodDescriptor:
         payload = await self._request(
             method="POST", url=self._pods_url, json=descriptor.to_primitive()
@@ -2039,34 +2171,19 @@ class KubeClient:
         url = self._generate_pod_url(name)
         return await self._request(method="GET", url=url)
 
-    async def get_raw_pods(self, all_namespaces: bool = False) -> RawPodListResult:
+    async def get_raw_pods(self, all_namespaces: bool = False) -> ListResult:
         url = self._generate_pods_url(all_namespaces)
         payload = await self._request(method="GET", url=url)
         self._check_status_payload(payload)
         assert payload["kind"] == "PodList"
-        return RawPodListResult.from_primitive(payload)
+        return ListResult.from_primitive(payload)
 
     async def watch_pods(
         self, all_namespaces: bool = False, resource_version: Optional[str] = None
-    ) -> AsyncIterator[Union[PodWatchEvent, WatchBookmarkEvent]]:
+    ) -> AsyncIterator[Union[WatchEvent, WatchBookmarkEvent]]:
         url = self._generate_pods_url(all_namespaces)
-        params = dict(watch="true", allowWatchBookmarks="true")
-        if resource_version:
-            params["resourceVersion"] = resource_version
-        assert self._client
-        async with self._client.get(
-            url, params=params, timeout=aiohttp.ClientTimeout()
-        ) as response:
-            if response.status == 410:
-                raise ResourceGoneException
-            async for line in response.content:
-                payload = json.loads(line)
-                if PodWatchEvent.is_error(payload):
-                    self._check_status_payload(payload["object"])
-                if WatchBookmarkEvent.is_bookmark(payload):
-                    yield WatchBookmarkEvent.from_primitive(payload)
-                else:
-                    yield PodWatchEvent.from_primitive(payload)
+        async for event in self._watch(url, resource_version=resource_version):
+            yield event
 
     async def get_pod_status(self, pod_id: str) -> PodStatus:
         pod = await self.get_pod(pod_id)
@@ -2464,28 +2581,28 @@ class KubeClient:
         return f"{proxy_url}/stats/summary"
 
 
-class PodEventHandler:
+class EventHandler:
     @abc.abstractmethod
-    async def init(self, raw_pods: list[dict[str, Any]]) -> None:
+    async def init(self, resources: list[dict[str, Any]]) -> None:
         pass
 
     @abc.abstractmethod
-    async def handle(self, event: PodWatchEvent) -> None:
+    async def handle(self, event: WatchEvent) -> None:
         pass
 
 
-class PodWatcher:
+class Watcher(abc.ABC):
     def __init__(self, kube_client: KubeClient) -> None:
         self._kube_client = kube_client
-        self._handlers: list[PodEventHandler] = []
+        self._handlers: list[EventHandler] = []
         self._watcher_task: Optional[asyncio.Task[None]] = None
 
-    def subscribe(self, handler: PodEventHandler) -> None:
+    def subscribe(self, handler: EventHandler) -> None:
         if self._watcher_task is not None:
             raise Exception("Subscription is not possible after watcher start")
         self._handlers.append(handler)
 
-    async def __aenter__(self) -> "PodWatcher":
+    async def __aenter__(self) -> "Watcher":
         await self.start()
         return self
 
@@ -2493,8 +2610,10 @@ class PodWatcher:
         await self.stop()
 
     async def start(self) -> None:
-        resource_version = await self._init()
-        self._watcher_task = asyncio.create_task(self._run(resource_version))
+        result = await self.list()
+        for handler in self._handlers:
+            await handler.init(result.items)
+        self._watcher_task = asyncio.create_task(self._run(result.resource_version))
 
     async def stop(self) -> None:
         if self._watcher_task is None:
@@ -2508,28 +2627,66 @@ class PodWatcher:
     async def _run(self, resource_version: str) -> None:
         while True:
             try:
-                async for event in self._kube_client.watch_pods(
-                    all_namespaces=True, resource_version=resource_version
-                ):
+                async for event in self.watch(resource_version):
                     if isinstance(event, WatchBookmarkEvent):
                         resource_version = event.resource_version
                         continue
                     for handler in self._handlers:
                         await handler.handle(event)
             except ResourceGoneException as exc:
-                logger.warning("Pods resource gone", exc_info=exc)
+                logger.warning("Resource gone", exc_info=exc)
             except aiohttp.ClientError as exc:
-                logger.warning("Watch pods client error", exc_info=exc)
+                logger.warning("Watch client error", exc_info=exc)
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
                 logger.warning("Unhandled error", exc_info=exc)
 
-    async def _init(self) -> str:
-        result = await self._kube_client.get_raw_pods(all_namespaces=True)
-        for handler in self._handlers:
-            await handler.init(result.raw_pods)
-        return result.resource_version
+    @abc.abstractmethod
+    async def list(self) -> ListResult:
+        pass
+
+    @abc.abstractmethod
+    async def watch(
+        self, resource_version: str
+    ) -> AsyncIterator[Union[WatchEvent, WatchBookmarkEvent]]:
+        yield  # type: ignore
+
+
+class NodeWatcher(Watcher):
+    def __init__(
+        self, kube_client: KubeClient, labels: Optional[dict[str, str]] = None
+    ) -> None:
+        super().__init__(kube_client)
+        self._kwargs = {"labels": labels}
+
+    async def list(self) -> ListResult:
+        return await self._kube_client.get_raw_nodes(**self._kwargs)
+
+    async def watch(
+        self, resource_version: str
+    ) -> AsyncIterator[Union[WatchEvent, WatchBookmarkEvent]]:
+        async for event in self._kube_client.watch_nodes(
+            resource_version=resource_version, **self._kwargs
+        ):
+            yield event
+
+
+class PodWatcher(Watcher):
+    def __init__(self, kube_client: KubeClient, all_namespaces: bool = True) -> None:
+        super().__init__(kube_client)
+        self._kwargs = {"all_namespaces": all_namespaces}
+
+    async def list(self) -> ListResult:
+        return await self._kube_client.get_raw_pods(**self._kwargs)
+
+    async def watch(
+        self, resource_version: str
+    ) -> AsyncIterator[Union[WatchEvent, WatchBookmarkEvent]]:
+        async for event in self._kube_client.watch_pods(
+            resource_version=resource_version, **self._kwargs
+        ):
+            yield event
 
 
 # https://github.com/kubernetes/kubernetes/blob/c285e781331a3785a7f436042c65c5641ce8a9e9/pkg/kubelet/preemption/preemption.go

--- a/platform_api/orchestrator/kube_orchestrator_preemption.py
+++ b/platform_api/orchestrator/kube_orchestrator_preemption.py
@@ -229,7 +229,7 @@ class KubeOrchestratorPreemption:
         exclude_nodes: Iterable[Node],
     ) -> tuple[Node | None, list[PodDescriptor]]:
         for node in self._get_nodes(exclude_nodes):
-            if not pod_to_schedule.can_be_scheduled(node.name, node.labels):
+            if not pod_to_schedule.can_be_scheduled(node.labels):
                 continue
             preemptible_pods = get_preemptible_pods(node.name)
             if not preemptible_pods:

--- a/platform_api/orchestrator/kube_orchestrator_preemption.py
+++ b/platform_api/orchestrator/kube_orchestrator_preemption.py
@@ -2,22 +2,21 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections import defaultdict
+from collections import Counter, defaultdict
 from collections.abc import Callable, Iterable
-from contextlib import suppress
 from typing import Any
 
+from platform_api.orchestrator.job_request import JobNotFoundException
+
 from .kube_client import (
+    EventHandler,
     KubeClient,
     KubePreemption,
     Node,
     NodeResources,
-    NotFoundException,
     PodDescriptor,
-    PodEventHandler,
     PodStatus,
-    PodWatcher,
-    PodWatchEvent,
+    WatchEvent,
     WatchEventType,
 )
 
@@ -67,89 +66,52 @@ class _Pod:
         return pod_resources
 
 
-class NodeResourcesHandler(PodEventHandler):
-    def __init__(self, kube_client: KubeClient) -> None:
-        self._kube_client = kube_client
+class NodesHandler(EventHandler):
+    def __init__(self) -> None:
         self._nodes: dict[str, Node] = {}
-        self._node_free_resources: dict[str, NodeResources] = {}
+
+    async def init(self, raw_nodes: list[dict[str, Any]]) -> None:
+        for raw_node in raw_nodes:
+            node = Node.from_primitive(raw_node)
+            if node.status.is_ready:
+                self._add_node(node)
+
+    async def handle(self, event: WatchEvent) -> None:
+        node = Node.from_primitive(event.resource)
+        if event.type == WatchEventType.DELETED or not node.status.is_ready:
+            self._remove_node(node)
+        else:
+            self._add_node(node)
+
+    def _add_node(self, node: Node) -> None:
+        self._nodes[node.name] = node
+
+    def _remove_node(self, node: Node) -> None:
+        self._nodes.pop(node.name, None)
+
+    def get_nodes(self) -> Iterable[Node]:
+        return self._nodes.values()
+
+
+class NodeResourcesHandler(EventHandler):
+    def __init__(self) -> None:
+        self._resource_requests: dict[str, NodeResources] = defaultdict(NodeResources)
+        self._pod_counts: Counter[str] = Counter()
         self._pod_node_names: dict[str, str] = {}
 
     async def init(self, raw_pods: list[dict[str, Any]]) -> None:
         for raw_pod in raw_pods:
             pod = _Pod(raw_pod)
-            if pod.status.is_scheduled and not pod.status.is_terminated:
-                await self._add_pod(pod)
-
-    async def handle(self, event: PodWatchEvent) -> None:
-        pod = _Pod(event.raw_pod)
-        if not pod.status.is_scheduled:
-            return
-        if event.type == WatchEventType.DELETED or pod.status.is_terminated:
-            self._remove_pod(pod)
-        else:
-            await self._add_pod(pod)
-
-    async def _add_pod(self, pod: _Pod) -> None:
-        pod_name = pod.name
-        if pod_name in self._pod_node_names:
-            return
-        node_name = pod.node_name
-        # Ignore error in case node was removed/lost but pod was not yet removed
-        with suppress(NotFoundException):
-            if node_name not in self._nodes:
-                node = await self._kube_client.get_node(node_name)
-                self._nodes[node_name] = node
-                self._node_free_resources[node_name] = node.allocatable_resources
-            self._pod_node_names[pod_name] = node_name
-            self._node_free_resources[node_name] -= pod.resource_requests
-
-    def _remove_pod(self, pod: _Pod) -> None:
-        pod_name = pod.name
-        if pod_name not in self._pod_node_names:
-            return
-        node_name = pod.node_name
-        node = self._nodes.get(node_name)
-        if node:
-            node_free_resources = self._node_free_resources[node_name]
-            node_free_resources += pod.resource_requests
-            if node.allocatable_resources == node_free_resources:
-                self._node_free_resources.pop(node_name, None)
-                self._nodes.pop(node_name, None)
-            else:
-                self._node_free_resources[node_name] = node_free_resources
-        self._pod_node_names.pop(pod_name, None)
-
-    def get_nodes(self) -> list[Node]:
-        return list(self._nodes.values())
-
-    def get_node_free_resources(self, node_name: str) -> NodeResources:
-        return self._node_free_resources.get(node_name) or NodeResources()
-
-    def get_pod_node_name(self, pod_name: str) -> str | None:
-        """
-        Get name of the node which runs pod.
-        Return None if pod is not in a Running state.
-        """
-        return self._pod_node_names.get(pod_name)
-
-    def _get_node_allocatable_resources(self, node_name: str) -> NodeResources:
-        node = self._nodes.get(node_name)
-        return node.allocatable_resources if node else NodeResources()
-
-
-class IdlePodsHandler(PodEventHandler):
-    def __init__(self) -> None:
-        self._pods: dict[str, dict[str, PodDescriptor]] = defaultdict(dict)
-
-    async def init(self, raw_pods: list[dict[str, Any]]) -> None:
-        for raw_pod in raw_pods:
-            pod = _Pod(raw_pod)
-            if pod.is_idle and pod.status.is_scheduled and not pod.status.is_terminated:
+            if (
+                not pod.is_idle
+                and pod.status.is_scheduled
+                and not pod.status.is_terminated
+            ):
                 self._add_pod(pod)
 
-    async def handle(self, event: PodWatchEvent) -> None:
-        pod = _Pod(event.raw_pod)
-        if not pod.is_idle or not pod.status.is_scheduled:
+    async def handle(self, event: WatchEvent) -> None:
+        pod = _Pod(event.resource)
+        if pod.is_idle or not pod.status.is_scheduled:
             return
         if event.type == WatchEventType.DELETED or pod.status.is_terminated:
             self._remove_pod(pod)
@@ -158,34 +120,52 @@ class IdlePodsHandler(PodEventHandler):
 
     def _add_pod(self, pod: _Pod) -> None:
         pod_name = pod.name
+        if pod_name in self._pod_node_names:
+            return
         node_name = pod.node_name
-        # there is an issue in k8s, elements in items don't have kind and version
-        pod.payload["kind"] = "Pod"
-        self._pods[node_name][pod_name] = PodDescriptor.from_primitive(pod.payload)
+        self._resource_requests[node_name] += pod.resource_requests
+        self._pod_counts[node_name] += 1
+        self._pod_node_names[pod_name] = node_name
 
     def _remove_pod(self, pod: _Pod) -> None:
-        node_name = pod.node_name
         pod_name = pod.name
-        pods = self._pods[node_name]
-        pods.pop(pod_name, None)
-        if not pods:
-            self._pods.pop(node_name, None)
+        if pod_name not in self._pod_node_names:
+            return
+        node_name = pod.node_name
+        resource_requests = self._resource_requests[node_name]
+        resource_requests -= pod.resource_requests
+        pod_counts = self._pod_counts[node_name]
+        pod_counts -= 1
+        if pod_counts == 0:
+            self._resource_requests.pop(node_name, None)
+            self._pod_counts.pop(node_name, None)
+        else:
+            self._resource_requests[node_name] = resource_requests
+            self._pod_counts[node_name] = pod_counts
+        self._pod_node_names.pop(pod_name, None)
 
-    def get_pods(self, node_name: str) -> list[PodDescriptor]:
-        pods = self._pods.get(node_name)
-        return list(pods.values()) if pods else []
+    def get_resource_requests(self, node_name: str) -> NodeResources:
+        return self._resource_requests.get(node_name) or NodeResources()
+
+    def get_pod_node_name(self, pod_name: str) -> str | None:
+        """
+        Get name of the node which runs pod.
+        Return None if pod is not in a Running state.
+        """
+        return self._pod_node_names.get(pod_name)
 
 
 class KubeOrchestratorPreemption:
-    def __init__(self, kube_client: KubeClient) -> None:
+    def __init__(
+        self,
+        kube_client: KubeClient,
+        nodes_handler: NodesHandler,
+        node_resources_handler: NodeResourcesHandler,
+    ) -> None:
         self._kube_client = kube_client
         self._kube_preemption = KubePreemption()
-        self._node_resources_handler = NodeResourcesHandler(kube_client)
-        self._idle_pods_handler = IdlePodsHandler()
-
-    def register(self, pod_watcher: PodWatcher) -> None:
-        pod_watcher.subscribe(self._node_resources_handler)
-        pod_watcher.subscribe(self._idle_pods_handler)
+        self._nodes_handler = nodes_handler
+        self._node_resources_handler = node_resources_handler
 
     async def preempt_pods(
         self,
@@ -199,14 +179,6 @@ class KubeOrchestratorPreemption:
                 preemptible_pods_by_node[node_name].append(pod)
         preempted_pods = await self._preempt_pods(
             pods_to_schedule, get_preemptible_pods=preemptible_pods_by_node.__getitem__
-        )
-        return preempted_pods
-
-    async def preempt_idle_pods(
-        self, pods_to_schedule: list[PodDescriptor]
-    ) -> list[PodDescriptor]:
-        preempted_pods = await self._preempt_pods(
-            pods_to_schedule, get_preemptible_pods=self._idle_pods_handler.get_pods
         )
         return preempted_pods
 
@@ -257,7 +229,7 @@ class KubeOrchestratorPreemption:
         exclude_nodes: Iterable[Node],
     ) -> tuple[Node | None, list[PodDescriptor]]:
         for node in self._get_nodes(exclude_nodes):
-            if not pod_to_schedule.can_be_scheduled(node.labels):
+            if not pod_to_schedule.can_be_scheduled(node.name, node.labels):
                 continue
             preemptible_pods = get_preemptible_pods(node.name)
             if not preemptible_pods:
@@ -286,12 +258,13 @@ class KubeOrchestratorPreemption:
 
     def _get_nodes(self, exclude: Iterable[Node]) -> list[Node]:
         def _create_key(node: Node) -> tuple[int, int, float]:
-            r = self._node_resources_handler.get_node_free_resources(node.name)
-            if not r:
+            requested = self._node_resources_handler.get_resource_requests(node.name)
+            free = node.get_free_resources(requested)
+            if not free:
                 return (0, 0, 0.0)
-            return (r.gpu or 0, r.memory, r.cpu)
+            return (free.gpu or 0, free.memory, free.cpu)
 
-        nodes = self._node_resources_handler.get_nodes()
+        nodes = self._nodes_handler.get_nodes()
         nodes = [n for n in nodes if n not in exclude]
         nodes.sort(key=_create_key)  # Try to preempt nodes with less resources first
         return nodes
@@ -299,7 +272,8 @@ class KubeOrchestratorPreemption:
     def _get_resources_to_preempt(
         self, pod_to_schedule: PodDescriptor, node: Node
     ) -> NodeResources:
-        free = self._node_resources_handler.get_node_free_resources(node.name)
+        requested = self._node_resources_handler.get_resource_requests(node.name)
+        free = node.get_free_resources(requested)
         required = pod_to_schedule.resources
         if not required:
             return NodeResources()
@@ -310,8 +284,12 @@ class KubeOrchestratorPreemption:
         )
 
     async def _delete_pods(self, pods: Iterable[PodDescriptor]) -> None:
-        tasks = [
-            asyncio.create_task(self._kube_client.delete_pod(pod.name)) for pod in pods
-        ]
+        tasks = [asyncio.create_task(self._delete_pod(pod.name)) for pod in pods]
         if tasks:
             await asyncio.wait(tasks)
+
+    async def _delete_pod(self, pod_name: str) -> None:
+        try:
+            await self._kube_client.delete_pod(pod_name)
+        except JobNotFoundException:
+            pass

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -407,7 +407,7 @@ class MyKubeClient(KubeClient):
                 print("Pods:")
                 pod_list = await self.get_raw_pods()
                 pods = sorted(
-                    pod_list.raw_pods, key=lambda p: p["spec"].get("nodeName", "")
+                    pod_list.items, key=lambda p: p["spec"].get("nodeName", "")
                 )
                 print(f"  {'Name':40s} {'CPU':5s} {'Memory':10s} {'Phase':9s} Node")
                 for pod in pods:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -79,7 +79,6 @@ class MockOrchestrator(Orchestrator):
             datetime.now, timezone.utc
         )
         self._successfully_deleted_jobs: list[Job] = []
-        self._idle_jobs: list[Job] = []
         self._preempted_jobs: list[Job] = []
 
     @property
@@ -163,12 +162,6 @@ class MockOrchestrator(Orchestrator):
     async def get_missing_disks(self, disks: list[Disk]) -> list[Disk]:
         pass
 
-    def start_idle_job(self, job: Job) -> None:
-        self._idle_jobs.append(job)
-
-    def get_idle_jobs(self) -> list[Job]:
-        return list(self._idle_jobs)
-
     def get_preempted_jobs(self) -> list[Job]:
         return list(self._preempted_jobs)
 
@@ -177,11 +170,6 @@ class MockOrchestrator(Orchestrator):
     ) -> list[Job]:
         self._preempted_jobs.extend(preemptible_jobs)
         return preemptible_jobs
-
-    async def preempt_idle_jobs(self, jobs_to_schedule: list[Job]) -> bool:
-        self._preempted_jobs.extend(self._idle_jobs)
-        self._idle_jobs.clear()
-        return True
 
 
 class MockJobsStorage(InMemoryJobsStorage):

--- a/tests/unit/test_kube_orchestrator.py
+++ b/tests/unit/test_kube_orchestrator.py
@@ -235,7 +235,26 @@ class TestPodDescriptor:
     def test_can_be_scheduled(self) -> None:
         pod = PodDescriptor(name="testname", image="testimage")
 
-        assert pod.can_be_scheduled({"node-pool": "cpu"}) is True
+        assert pod.can_be_scheduled("minikube", {"node-pool": "cpu"}) is True
+
+    def test_can_be_scheduled_with_node_name(self) -> None:
+        pod = PodDescriptor(
+            name="testname",
+            image="testimage",
+            node_name="minikube",
+            node_selector={"job": "true"},
+            node_affinity=NodeAffinity(
+                required=[
+                    NodeSelectorTerm(
+                        [NodeSelectorRequirement.create_in("node-pool", "cpu")]
+                    )
+                ]
+            ),
+        )
+
+        assert pod.can_be_scheduled("minikube", {}) is True
+        assert pod.can_be_scheduled("minikube2", {"job": "true"}) is False
+        assert pod.can_be_scheduled("minikube2", {"node-pool": "cpu"}) is False
 
     def test_can_be_scheduled_with_node_affinity(self) -> None:
         pod = PodDescriptor(
@@ -250,8 +269,8 @@ class TestPodDescriptor:
             ),
         )
 
-        assert pod.can_be_scheduled({"node-pool": "cpu"}) is True
-        assert pod.can_be_scheduled({"node-pool": "gpu"}) is False
+        assert pod.can_be_scheduled("minikube", {"node-pool": "cpu"}) is True
+        assert pod.can_be_scheduled("minikube", {"node-pool": "gpu"}) is False
 
     def test_can_be_scheduled_with_node_selector(self) -> None:
         pod = PodDescriptor(
@@ -260,9 +279,12 @@ class TestPodDescriptor:
             node_selector={"job": "true", "node-pool": "cpu"},
         )
 
-        assert pod.can_be_scheduled({"job": "true", "node-pool": "cpu"}) is True
-        assert pod.can_be_scheduled({"node-pool": "cpu"}) is False
-        assert pod.can_be_scheduled({"job": "true"}) is False
+        assert (
+            pod.can_be_scheduled("minikube", {"job": "true", "node-pool": "cpu"})
+            is True
+        )
+        assert pod.can_be_scheduled("minikube", {"node-pool": "cpu"}) is False
+        assert pod.can_be_scheduled("minikube", {"job": "true"}) is False
 
     def test_can_be_scheduled_with_node_affinity_and_selector(self) -> None:
         pod = PodDescriptor(
@@ -278,9 +300,12 @@ class TestPodDescriptor:
             ),
         )
 
-        assert pod.can_be_scheduled({"job": "true", "node-pool": "cpu"}) is True
-        assert pod.can_be_scheduled({"node-pool": "cpu"}) is False
-        assert pod.can_be_scheduled({"job": "true"}) is False
+        assert (
+            pod.can_be_scheduled("minikube", {"job": "true", "node-pool": "cpu"})
+            is True
+        )
+        assert pod.can_be_scheduled("minikube", {"node-pool": "cpu"}) is False
+        assert pod.can_be_scheduled("minikube", {"job": "true"}) is False
 
     def test_to_primitive_defaults(self) -> None:
         pod = PodDescriptor(name="testname", image="testimage")

--- a/tests/unit/test_kube_orchestrator.py
+++ b/tests/unit/test_kube_orchestrator.py
@@ -235,26 +235,7 @@ class TestPodDescriptor:
     def test_can_be_scheduled(self) -> None:
         pod = PodDescriptor(name="testname", image="testimage")
 
-        assert pod.can_be_scheduled("minikube", {"node-pool": "cpu"}) is True
-
-    def test_can_be_scheduled_with_node_name(self) -> None:
-        pod = PodDescriptor(
-            name="testname",
-            image="testimage",
-            node_name="minikube",
-            node_selector={"job": "true"},
-            node_affinity=NodeAffinity(
-                required=[
-                    NodeSelectorTerm(
-                        [NodeSelectorRequirement.create_in("node-pool", "cpu")]
-                    )
-                ]
-            ),
-        )
-
-        assert pod.can_be_scheduled("minikube", {}) is True
-        assert pod.can_be_scheduled("minikube2", {"job": "true"}) is False
-        assert pod.can_be_scheduled("minikube2", {"node-pool": "cpu"}) is False
+        assert pod.can_be_scheduled({"node-pool": "cpu"}) is True
 
     def test_can_be_scheduled_with_node_affinity(self) -> None:
         pod = PodDescriptor(
@@ -269,8 +250,8 @@ class TestPodDescriptor:
             ),
         )
 
-        assert pod.can_be_scheduled("minikube", {"node-pool": "cpu"}) is True
-        assert pod.can_be_scheduled("minikube", {"node-pool": "gpu"}) is False
+        assert pod.can_be_scheduled({"node-pool": "cpu"}) is True
+        assert pod.can_be_scheduled({"node-pool": "gpu"}) is False
 
     def test_can_be_scheduled_with_node_selector(self) -> None:
         pod = PodDescriptor(
@@ -279,12 +260,9 @@ class TestPodDescriptor:
             node_selector={"job": "true", "node-pool": "cpu"},
         )
 
-        assert (
-            pod.can_be_scheduled("minikube", {"job": "true", "node-pool": "cpu"})
-            is True
-        )
-        assert pod.can_be_scheduled("minikube", {"node-pool": "cpu"}) is False
-        assert pod.can_be_scheduled("minikube", {"job": "true"}) is False
+        assert pod.can_be_scheduled({"job": "true", "node-pool": "cpu"}) is True
+        assert pod.can_be_scheduled({"node-pool": "cpu"}) is False
+        assert pod.can_be_scheduled({"job": "true"}) is False
 
     def test_can_be_scheduled_with_node_affinity_and_selector(self) -> None:
         pod = PodDescriptor(
@@ -300,12 +278,9 @@ class TestPodDescriptor:
             ),
         )
 
-        assert (
-            pod.can_be_scheduled("minikube", {"job": "true", "node-pool": "cpu"})
-            is True
-        )
-        assert pod.can_be_scheduled("minikube", {"node-pool": "cpu"}) is False
-        assert pod.can_be_scheduled("minikube", {"job": "true"}) is False
+        assert pod.can_be_scheduled({"job": "true", "node-pool": "cpu"}) is True
+        assert pod.can_be_scheduled({"node-pool": "cpu"}) is False
+        assert pod.can_be_scheduled({"job": "true"}) is False
 
     def test_to_primitive_defaults(self) -> None:
         pod = PodDescriptor(name="testname", image="testimage")


### PR DESCRIPTION
Add NodesWatcher and NodesHandler to track current Ready cluster nodes. They will be used to check if pods can be scheduled in the cluster.