### PR TITLE
no-org label in job

### DIFF
--- a/platform_api/orchestrator/kube_orchestrator.py
+++ b/platform_api/orchestrator/kube_orchestrator.py
@@ -458,7 +458,7 @@ class KubeOrchestrator(Orchestrator):
         return {"platform.neuromation.io/user": job.owner.replace("/", "--")}
 
     def _get_org_pod_labels(self, job: Job) -> dict[str, str]:
-        return {"platform.neuromation.io/org": job.org_name or "no_org"}
+        return {"platform.neuromation.io/org": job.org_name or ""}
 
     def _get_job_labels(self, job: Job) -> dict[str, str]:
         return {"platform.neuromation.io/job": job.id}

--- a/platform_api/orchestrator/kube_orchestrator.py
+++ b/platform_api/orchestrator/kube_orchestrator.py
@@ -458,9 +458,7 @@ class KubeOrchestrator(Orchestrator):
         return {"platform.neuromation.io/user": job.owner.replace("/", "--")}
 
     def _get_org_pod_labels(self, job: Job) -> dict[str, str]:
-        if not job.org_name:
-            return {}
-        return {"platform.neuromation.io/org": job.org_name}
+        return {"platform.neuromation.io/org": job.org_name or "<no-org>"}
 
     def _get_job_labels(self, job: Job) -> dict[str, str]:
         return {"platform.neuromation.io/job": job.id}

--- a/platform_api/orchestrator/kube_orchestrator.py
+++ b/platform_api/orchestrator/kube_orchestrator.py
@@ -458,7 +458,7 @@ class KubeOrchestrator(Orchestrator):
         return {"platform.neuromation.io/user": job.owner.replace("/", "--")}
 
     def _get_org_pod_labels(self, job: Job) -> dict[str, str]:
-        return {"platform.neuromation.io/org": job.org_name or "<no-org>"}
+        return {"platform.neuromation.io/org": job.org_name or "no_org"}
 
     def _get_job_labels(self, job: Job) -> dict[str, str]:
         return {"platform.neuromation.io/job": job.id}

--- a/tests/integration/test_kube_orchestrator.py
+++ b/tests/integration/test_kube_orchestrator.py
@@ -1258,6 +1258,7 @@ class TestKubeOrchestrator:
             "platform.neuromation.io/job": job.id,
             "platform.neuromation.io/preset": job.preset_name,
             "platform.neuromation.io/user": job.owner,
+            "platform.neuromation.io/org": "<no-org>",
         }
 
         policy_name = "neurouser-" + job.owner
@@ -1334,6 +1335,7 @@ class TestKubeOrchestrator:
         assert raw_pod["metadata"]["labels"] == {
             "platform.neuromation.io/job": job.id,
             "platform.neuromation.io/user": job.owner,
+            "platform.neuromation.io/org": "<no-org>",
             "platform.neuromation.io/gpu-model": job.gpu_model_id,
         }
 

--- a/tests/integration/test_kube_orchestrator.py
+++ b/tests/integration/test_kube_orchestrator.py
@@ -1258,7 +1258,7 @@ class TestKubeOrchestrator:
             "platform.neuromation.io/job": job.id,
             "platform.neuromation.io/preset": job.preset_name,
             "platform.neuromation.io/user": job.owner,
-            "platform.neuromation.io/org": "no_org",
+            "platform.neuromation.io/org": "",
         }
 
         policy_name = "neurouser-" + job.owner
@@ -1335,7 +1335,7 @@ class TestKubeOrchestrator:
         assert raw_pod["metadata"]["labels"] == {
             "platform.neuromation.io/job": job.id,
             "platform.neuromation.io/user": job.owner,
-            "platform.neuromation.io/org": "no_org",
+            "platform.neuromation.io/org": "",
             "platform.neuromation.io/gpu-model": job.gpu_model_id,
         }
 

--- a/tests/integration/test_kube_orchestrator.py
+++ b/tests/integration/test_kube_orchestrator.py
@@ -1258,7 +1258,7 @@ class TestKubeOrchestrator:
             "platform.neuromation.io/job": job.id,
             "platform.neuromation.io/preset": job.preset_name,
             "platform.neuromation.io/user": job.owner,
-            "platform.neuromation.io/org": "<no-org>",
+            "platform.neuromation.io/org": "<no_org>",
         }
 
         policy_name = "neurouser-" + job.owner
@@ -1335,7 +1335,7 @@ class TestKubeOrchestrator:
         assert raw_pod["metadata"]["labels"] == {
             "platform.neuromation.io/job": job.id,
             "platform.neuromation.io/user": job.owner,
-            "platform.neuromation.io/org": "<no-org>",
+            "platform.neuromation.io/org": "<no_org>",
             "platform.neuromation.io/gpu-model": job.gpu_model_id,
         }
 

--- a/tests/integration/test_kube_orchestrator.py
+++ b/tests/integration/test_kube_orchestrator.py
@@ -1258,7 +1258,7 @@ class TestKubeOrchestrator:
             "platform.neuromation.io/job": job.id,
             "platform.neuromation.io/preset": job.preset_name,
             "platform.neuromation.io/user": job.owner,
-            "platform.neuromation.io/org": "<no_org>",
+            "platform.neuromation.io/org": "no_org",
         }
 
         policy_name = "neurouser-" + job.owner
@@ -1335,7 +1335,7 @@ class TestKubeOrchestrator:
         assert raw_pod["metadata"]["labels"] == {
             "platform.neuromation.io/job": job.id,
             "platform.neuromation.io/user": job.owner,
-            "platform.neuromation.io/org": "<no_org>",
+            "platform.neuromation.io/org": "no_org",
             "platform.neuromation.io/gpu-model": job.gpu_model_id,
         }
 

--- a/tests/integration/test_kube_orchestrator.py
+++ b/tests/integration/test_kube_orchestrator.py
@@ -1369,6 +1369,7 @@ class TestKubeOrchestrator:
         assert service.labels == {
             "platform.neuromation.io/job": job.id,
             "platform.neuromation.io/user": job.owner,
+            "platform.neuromation.io/org": "",
         }
 
         ingress_name = job.id
@@ -1376,6 +1377,7 @@ class TestKubeOrchestrator:
         assert ingress.labels == {
             "platform.neuromation.io/job": job.id,
             "platform.neuromation.io/user": job.owner,
+            "platform.neuromation.io/org": "",
         }
 
     async def test_named_job_resource_labels(
@@ -1410,6 +1412,7 @@ class TestKubeOrchestrator:
         assert service.labels == {
             "platform.neuromation.io/job": job.id,
             "platform.neuromation.io/user": job.owner,
+            "platform.neuromation.io/org": "",
         }
 
         ingress_name = job.id
@@ -1417,6 +1420,7 @@ class TestKubeOrchestrator:
         assert ingress.labels == {
             "platform.neuromation.io/job": job.id,
             "platform.neuromation.io/user": job.owner,
+            "platform.neuromation.io/org": "",
             "platform.neuromation.io/job-name": job.name,
         }
 


### PR DESCRIPTION
Add empty label if job is not assigned to any org. This is required for reports to apply correctly org filtering.