### PR TITLE
Integrate energy into JobsScheduler

### DIFF
--- a/platform_api/cluster_config_factory.py
+++ b/platform_api/cluster_config_factory.py
@@ -9,6 +9,7 @@ import trafaret as t
 from yarl import URL
 
 from .cluster_config import (
+    DEFAULT_ENERGY_SCHEDULE_NAME,
     ClusterConfig,
     EnergyConfig,
     EnergySchedule,
@@ -196,5 +197,7 @@ class ClusterConfigFactory:
             for s in payload.get("energy", {}).get("schedules", [])
             if (schedule := self._create_energy_schedule(s, timezone=timezone))
         }
-        schedules["default"] = EnergySchedule.create_default(timezone=timezone)
+        schedules[DEFAULT_ENERGY_SCHEDULE_NAME] = EnergySchedule.create_default(
+            timezone=timezone
+        )
         return EnergyConfig(schedules=list(schedules.values()))

--- a/platform_api/orchestrator/job.py
+++ b/platform_api/orchestrator/job.py
@@ -502,6 +502,8 @@ class JobRecord:
             result["logs_removed"] = self.logs_removed
         if self.org_name:
             result["org_name"] = self.org_name
+        if self.energy_schedule_name:
+            result["energy_schedule_name"] = self.energy_schedule_name
         return result
 
     @classmethod
@@ -545,6 +547,9 @@ class JobRecord:
             else None,
             being_dropped=payload.get("being_dropped", False),
             logs_removed=payload.get("logs_removed", False),
+            energy_schedule_name=payload.get(
+                "energy_schedule_name", cls.energy_schedule_name
+            ),
         )
 
     @staticmethod

--- a/platform_api/orchestrator/job.py
+++ b/platform_api/orchestrator/job.py
@@ -12,6 +12,7 @@ from yarl import URL
 
 from platform_api.cluster_config import OrchestratorConfig
 
+from ..cluster_config import DEFAULT_ENERGY_SCHEDULE_NAME
 from ..resource import Preset
 from .job_request import (
     ContainerResources,
@@ -301,6 +302,7 @@ class JobRecord:
     schedule_timeout: Optional[float] = None
     restart_policy: JobRestartPolicy = JobRestartPolicy.NEVER
     priority: JobPriority = JobPriority.NORMAL
+    energy_schedule_name: str = DEFAULT_ENERGY_SCHEDULE_NAME
 
     # Billing in credits
     fully_billed: bool = False  # True if job has final price

--- a/platform_api/orchestrator/jobs_service.py
+++ b/platform_api/orchestrator/jobs_service.py
@@ -234,6 +234,7 @@ class JobsService:
         max_run_time_minutes: Optional[int] = None,
         restart_policy: JobRestartPolicy = JobRestartPolicy.NEVER,
         priority: JobPriority = JobPriority.NORMAL,
+        energy_schedule_name: Optional[str] = None,
     ) -> tuple[Job, Status]:
         base_name = user.name.split("/", 1)[
             0
@@ -298,6 +299,7 @@ class JobsService:
             restart_policy=restart_policy,
             privileged=privileged,
             priority=priority,
+            energy_schedule_name=energy_schedule_name,
         )
         job_id = job_request.job_id
 

--- a/platform_api/orchestrator/poller_service.py
+++ b/platform_api/orchestrator/poller_service.py
@@ -19,7 +19,7 @@ from platform_api.cluster import (
     ClusterNotAvailable,
     ClusterNotFound,
 )
-from platform_api.cluster_config import EnergyConfig, OrchestratorConfig
+from platform_api.cluster_config import ClusterConfig, OrchestratorConfig
 from platform_api.config import JobsConfig, JobsSchedulerConfig
 
 from ..utils.asyncio import run_and_log_exceptions
@@ -42,6 +42,9 @@ logger = logging.getLogger(__file__)
 class SchedulingResult:
     jobs_to_start: list[JobRecord] = field(default_factory=list)
     jobs_to_update: list[JobRecord] = field(default_factory=list)
+    # `jobs_to_replace` is a list of jobs that may be replaced by `jobs_to_start` in
+    # case of a congested cluster.
+    jobs_to_replace: list[JobRecord] = field(default_factory=list)
     jobs_to_suspend: list[JobRecord] = field(default_factory=list)
 
 
@@ -51,6 +54,7 @@ current_datetime_factory = partial(datetime.now, timezone.utc)
 class JobsScheduler:
     def __init__(
         self,
+        *,
         config: JobsSchedulerConfig,
         admin_client: AdminClient,
         cluster_holder: ClusterHolder,
@@ -148,19 +152,32 @@ class JobsScheduler:
 
         return jobs_to_update
 
+    async def _get_cluster_config(self) -> Optional[ClusterConfig]:
+        try:
+            async with self._cluster_holder.get() as cluster:
+                return cluster.config
+        except (ClusterNotFound, ClusterNotAvailable):
+            return None
+
     def _check_energy_schedule(
-        self, *, job: JobRecord, energy_config: EnergyConfig, current_time: datetime
+        self,
+        *,
+        job: JobRecord,
+        cluster_config: Optional[ClusterConfig],
+        current_time: datetime,
     ) -> bool:
-        if not job.scheduler_enabled:
+        if (
+            not cluster_config
+            or not cluster_config.orchestrator.allow_scheduler_enabled_job
+            or not job.scheduler_enabled
+        ):
             return True
-        schedule = energy_config.get_schedule(job.energy_schedule_name)
-        return schedule.check_time(self._current_datetime_factory())
+        schedule = cluster_config.energy.get_schedule(job.energy_schedule_name)
+        return schedule.check_time(current_time)
 
     async def schedule(self, unfinished: list[JobRecord]) -> SchedulingResult:
-        current_time = self._current_datetime_factory()
-        async with self._cluster_holder.get() as cluster:
-            cluster_config = cluster.config
-
+        now = self._current_datetime_factory()
+        cluster_config = await self._get_cluster_config()
         unfinished = await self._enforce_running_job_quota(unfinished)
 
         if not unfinished:
@@ -168,15 +185,15 @@ class JobsScheduler:
 
         jobs_to_start: list[JobRecord] = []
         jobs_to_update: list[JobRecord] = []
+        jobs_to_replace: list[JobRecord] = []
         jobs_to_suspend: list[JobRecord] = []
-        now = self._current_datetime_factory()
 
         # Process pending jobs
         for job in unfinished:
             if not job.status.is_pending:
                 continue
             if not self._check_energy_schedule(
-                job=job, energy_config=cluster_config.energy, current_time=current_time
+                job=job, cluster_config=cluster_config, current_time=now
             ):
                 continue
             jobs_to_start.append(job)
@@ -188,21 +205,18 @@ class JobsScheduler:
         for job in unfinished:
             if not job.status.is_running:
                 continue
+            if not self._check_energy_schedule(
+                job=job, cluster_config=cluster_config, current_time=now
+            ):
+                jobs_to_suspend.append(job)
+                continue
             if job.scheduler_enabled:
                 continued_at = job.status_history.continued_at
                 assert continued_at, "Running job should have continued_at"
-                fits_energy_schedule = self._check_energy_schedule(
-                    job=job,
-                    energy_config=cluster_config.energy,
-                    current_time=current_time,
-                )
-                if (
-                    now - continued_at < self._config.run_quantum
-                    and fits_energy_schedule
-                ):
+                if now - continued_at < self._config.run_quantum:
                     jobs_to_update.append(job)
                 else:
-                    jobs_to_suspend.append(job)
+                    jobs_to_replace.append(job)
             else:
                 jobs_to_update.append(job)
 
@@ -210,12 +224,10 @@ class JobsScheduler:
         for job in unfinished:
             if not job.status.is_suspended:
                 continue
-            suspended_at = job.status_history.current.transition_time
             fits_energy_schedule = self._check_energy_schedule(
-                job=job,
-                energy_config=cluster_config.energy,
-                current_time=current_time,
+                job=job, cluster_config=cluster_config, current_time=now
             )
+            suspended_at = job.status_history.current.transition_time
             if fits_energy_schedule and (
                 not jobs_to_start
                 or job.priority > max_job_to_start_priority
@@ -237,6 +249,7 @@ class JobsScheduler:
         return SchedulingResult(
             jobs_to_start=jobs_to_start,
             jobs_to_update=jobs_to_update,
+            jobs_to_replace=jobs_to_replace,
             jobs_to_suspend=jobs_to_suspend,
         )
 
@@ -330,7 +343,9 @@ class JobsPollerService:
         result = await self._scheduler.schedule(unfinished)
 
         await run_and_log_exceptions(
-            self._start_jobs_wrapper(result.jobs_to_start, result.jobs_to_suspend)
+            self._start_jobs_wrapper(
+                result.jobs_to_start, result.jobs_to_replace, result.jobs_to_suspend
+            )
         )
 
         await run_and_log_exceptions(
@@ -356,20 +371,30 @@ class JobsPollerService:
         )
 
     async def _start_jobs_wrapper(
-        self, records_to_start: list[JobRecord], records_to_suspend: list[JobRecord]
+        self,
+        records_to_start: list[JobRecord],
+        records_to_replace: list[JobRecord],
+        records_to_suspend: list[JobRecord],
     ) -> None:
         try:
             async with AsyncExitStack() as stack:
-                for record in itertools.chain(records_to_start, records_to_suspend):
+                for record in itertools.chain(
+                    records_to_start, records_to_replace, records_to_suspend
+                ):
                     await stack.enter_async_context(self._update_job(record))
 
                 try:
                     async with self._cluster_holder.get() as cluster:
+                        await self._suspend_jobs(
+                            cluster=cluster, records=records_to_suspend
+                        )
                         await self._start_jobs(
-                            cluster, records_to_start, records_to_suspend
+                            cluster, records_to_start, records_to_replace
                         )
                 except ClusterNotFound as cluster_err:
-                    for record in itertools.chain(records_to_start, records_to_suspend):
+                    for record in itertools.chain(
+                        records_to_start, records_to_replace, records_to_suspend
+                    ):
                         # marking PENDING/RUNNING job as FAILED
                         logger.warning(
                             "Failed to get job '%s' status. Reason: %s",
@@ -435,7 +460,7 @@ class JobsPollerService:
                     # Do not materialize next jobs until job is scheduled
                     stop_materializing = True
                     continue
-                suspended_jobs = await self._suspend_jobs(
+                suspended_jobs = await self._replace_jobs(
                     cluster.orchestrator, job, jobs_to_suspend
                 )
                 if suspended_jobs:
@@ -454,6 +479,9 @@ class JobsPollerService:
                     await self._revoke_pass_config(job)
                     job.materialized = False
 
+            # `_replace_jobs` may have suspended some but not all jobs.
+            # If jobs were not suspended, we either want to start them, or update their
+            # statuses.
             for job in jobs_to_suspend:
                 if job.status != JobStatus.SUSPENDED:
                     await self._update_job_status(cluster.orchestrator, job)
@@ -462,7 +490,7 @@ class JobsPollerService:
             # the job as deleted. suppressing.
             logger.warning("Could not start jobs. Reason: '%s'", exc)
 
-    async def _suspend_jobs(
+    async def _replace_jobs(
         self,
         orchestrator: Orchestrator,
         job_to_start: Job,
@@ -490,6 +518,20 @@ class JobsPollerService:
             )
             await self._revoke_pass_config(job_to_start)
             return []
+
+    async def _suspend_jobs(
+        self, *, cluster: Cluster, records: list[JobRecord]
+    ) -> None:
+        if not records:
+            return
+        try:
+            for record in records:
+                job = self._make_job(record, cluster)
+                await cluster.orchestrator.delete_job(job)
+                job.status = JobStatus.SUSPENDED
+                job.materialized = False
+        except JobException as exc:
+            logger.info("Failed to suspend jobs. Reason: %s", exc)
 
     async def _update_job_status_wrapper(self, job_record: JobRecord) -> None:
         try:

--- a/platform_api/poller_main.py
+++ b/platform_api/poller_main.py
@@ -81,7 +81,7 @@ async def create_app(
     async def _init_app(app: aiohttp.web.Application) -> AsyncIterator[None]:
         async with AsyncExitStack() as exit_stack:
 
-            logger.info("Initializing Auth client")
+            logger.info("Initializing AuthClient")
             auth_client = await exit_stack.enter_async_context(
                 AuthClient(
                     url=config.auth.server_endpoint_url,
@@ -101,12 +101,12 @@ async def create_app(
                 app=app, auth_client=auth_client, auth_scheme=AuthScheme.BEARER
             )
 
-            logger.info("Initializing Cluster Registry")
+            logger.info("Initializing ClusterHolder")
             cluster_holder = await exit_stack.enter_async_context(
                 ClusterHolder(factory=create_cluster_factory(config))
             )
 
-            logger.info("Initializing Config client")
+            logger.info("Initializing ConfigClient")
             config_client = await exit_stack.enter_async_context(
                 ConfigClient(
                     base_url=config.config_url,
@@ -129,7 +129,11 @@ async def create_app(
             jobs_poller_service = JobsPollerService(
                 cluster_holder=cluster_holder,
                 jobs_config=config.jobs,
-                scheduler=JobsScheduler(config.scheduler, admin_client=admin_client),
+                scheduler=JobsScheduler(
+                    config.scheduler,
+                    cluster_holder=cluster_holder,
+                    admin_client=admin_client,
+                ),
                 auth_client=auth_client,
                 api=poller_api,
             )

--- a/platform_api/poller_main.py
+++ b/platform_api/poller_main.py
@@ -130,9 +130,9 @@ async def create_app(
                 cluster_holder=cluster_holder,
                 jobs_config=config.jobs,
                 scheduler=JobsScheduler(
-                    config.scheduler,
-                    cluster_holder=cluster_holder,
+                    config=config.scheduler,
                     admin_client=admin_client,
+                    cluster_holder=cluster_holder,
                 ),
                 auth_client=auth_client,
                 api=poller_api,

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -904,6 +904,7 @@ class TestJob:
             "privileged": False,
             "total_price_credits": "0",
             "priority": 0,
+            "energy_schedule_name": "default",
         }
 
     def test_to_primitive_with_max_run_time(
@@ -942,6 +943,7 @@ class TestJob:
             "privileged": False,
             "total_price_credits": "0",
             "priority": 0,
+            "energy_schedule_name": "default",
         }
 
     def test_to_primitive_with_tags(
@@ -1326,6 +1328,7 @@ class TestJob:
             "privileged": False,
             "total_price_credits": "0",
             "priority": 0,
+            "energy_schedule_name": "green",
         }
         actual = Job.to_primitive(
             Job.from_primitive(mock_orchestrator.config, expected)


### PR DESCRIPTION
Our preemption mechanism worked only in case of congested cluster resources. We never suspended jobs that could still run. In case of congestion a pending/suspended job is to replace other running jobs every once in a while.

Here in this PR we introduce a small change that will allow us to suspend jobs even when there are free resources in the cluster. in `JobsScheduler` we start to track `jobs_to_replace` as potential candidates for swaps with pending/suspended jobs  and `jobs_to_suspend` for unconditional suspension.