### PR TITLE
implicitly create default projects in tests

### DIFF
--- a/tests/integration/auth.py
+++ b/tests/integration/auth.py
@@ -170,8 +170,7 @@ class UserFactory(Protocol):
         | None = None,
         cluster_user_role: ClusterUserRoleType = ClusterUserRoleType.USER,
         org_user_role: OrgUserRoleType = OrgUserRoleType.USER,
-        do_create_cluster_project: bool = True,
-        do_create_org_project: bool = True,
+        do_create_project: bool = True,
     ) -> _User:
         ...
 
@@ -192,8 +191,7 @@ async def regular_user_factory(
         | None = None,
         cluster_user_role: ClusterUserRoleType = ClusterUserRoleType.USER,
         org_user_role: OrgUserRoleType = OrgUserRoleType.USER,
-        do_create_cluster_project: bool = True,
-        do_create_org_project: bool = True,
+        do_create_project: bool = True,
     ) -> _User:
         if not name:
             name = random_str()
@@ -241,12 +239,6 @@ async def regular_user_factory(
                     )
                 except ClientResponseError:
                     pass
-                if do_create_org_project:
-                    # creating a default project in the tenant for the user
-                    try:
-                        await user_admin_client.create_project(name, cluster, org_name)
-                    except ClientResponseError:
-                        pass
             try:
                 await admin_client.create_cluster_user(
                     cluster_name=cluster,
@@ -258,10 +250,10 @@ async def regular_user_factory(
                 )
             except ClientResponseError:
                 pass
-            if do_create_cluster_project:
-                # creating a default project in the cluster for the user
+            if do_create_project:
+                # creating a default project in the tenant for the user
                 try:
-                    await user_admin_client.create_project(name, cluster, None)
+                    await user_admin_client.create_project(name, cluster, org_name)
                 except ClientResponseError:
                     pass
         return _User(

--- a/tests/integration/auth.py
+++ b/tests/integration/auth.py
@@ -170,6 +170,8 @@ class UserFactory(Protocol):
         | None = None,
         cluster_user_role: ClusterUserRoleType = ClusterUserRoleType.USER,
         org_user_role: OrgUserRoleType = OrgUserRoleType.USER,
+        do_create_cluster_project: bool = True,
+        do_create_org_project: bool = True,
     ) -> _User:
         ...
 
@@ -190,6 +192,8 @@ async def regular_user_factory(
         | None = None,
         cluster_user_role: ClusterUserRoleType = ClusterUserRoleType.USER,
         org_user_role: OrgUserRoleType = OrgUserRoleType.USER,
+        do_create_cluster_project: bool = True,
+        do_create_org_project: bool = True,
     ) -> _User:
         if not name:
             name = random_str()
@@ -237,11 +241,12 @@ async def regular_user_factory(
                     )
                 except ClientResponseError:
                     pass
-                # creating a default project in the tenant for the user
-                try:
-                    await user_admin_client.create_project(name, cluster, org_name)
-                except ClientResponseError:
-                    pass
+                if do_create_org_project:
+                    # creating a default project in the tenant for the user
+                    try:
+                        await user_admin_client.create_project(name, cluster, org_name)
+                    except ClientResponseError:
+                        pass
             try:
                 await admin_client.create_cluster_user(
                     cluster_name=cluster,
@@ -253,11 +258,12 @@ async def regular_user_factory(
                 )
             except ClientResponseError:
                 pass
-            # creating a default project in the cluster for the user
-            try:
-                await user_admin_client.create_project(name, cluster, None)
-            except ClientResponseError:
-                pass
+            if do_create_cluster_project:
+                # creating a default project in the cluster for the user
+                try:
+                    await user_admin_client.create_project(name, cluster, None)
+                except ClientResponseError:
+                    pass
         return _User(
             name=name,
             token=user_token,

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -234,8 +234,7 @@ class TestApi:
                 ("test-cluster", Balance(), Quota()),
                 ("testcluster2", Balance(), Quota()),
             ],
-            do_create_cluster_project=False,
-            do_create_org_project=False,
+            do_create_project=False,
         )
         async with client.get(url, headers=regular_user.headers) as resp:
             assert resp.status == HTTPOk.status_code, await resp.text()
@@ -452,8 +451,7 @@ class TestApi:
                 ("test-cluster", "org2", Balance(), Quota()),
             ],
             cluster_user_role=ClusterUserRoleType.MANAGER,
-            do_create_cluster_project=False,
-            do_create_org_project=False,
+            do_create_project=False,
         )
 
         admin_client = await admin_client_factory(regular_user.token)
@@ -627,8 +625,7 @@ class TestApi:
         admin_url: URL,
     ) -> None:
         regular_user = await regular_user_factory(
-            do_create_cluster_project=False,
-            do_create_org_project=False,
+            do_create_project=False,
         )
         url = api_with_oauth.config_url
         async with client.get(url, headers=regular_user.headers) as resp:

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -234,6 +234,8 @@ class TestApi:
                 ("test-cluster", Balance(), Quota()),
                 ("testcluster2", Balance(), Quota()),
             ],
+            do_create_cluster_project=False,
+            do_create_org_project=False,
         )
         async with client.get(url, headers=regular_user.headers) as resp:
             assert resp.status == HTTPOk.status_code, await resp.text()
@@ -450,6 +452,8 @@ class TestApi:
                 ("test-cluster", "org2", Balance(), Quota()),
             ],
             cluster_user_role=ClusterUserRoleType.MANAGER,
+            do_create_cluster_project=False,
+            do_create_org_project=False,
         )
 
         admin_client = await admin_client_factory(regular_user.token)
@@ -619,9 +623,13 @@ class TestApi:
         self,
         api_with_oauth: ApiConfig,
         client: aiohttp.ClientSession,
-        regular_user: _User,
+        regular_user_factory: UserFactory,
         admin_url: URL,
     ) -> None:
+        regular_user = await regular_user_factory(
+            do_create_cluster_project=False,
+            do_create_org_project=False,
+        )
         url = api_with_oauth.config_url
         async with client.get(url, headers=regular_user.headers) as resp:
             assert resp.status == HTTPOk.status_code, await resp.text()


### PR DESCRIPTION
After we patched platform-admin to not add cluster-related resource permissions by default, all new users must be within a project to interact with the cluster.