### PR TITLE
support external jobs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: Run unit tests
       run: make test_unit
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: .coverage-unit.xml
@@ -94,7 +94,7 @@ jobs:
     - name: Run integration tests
       run: make test_integration
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: .coverage-integration.xml

--- a/charts/platform-api-poller/templates/deployment.yml
+++ b/charts/platform-api-poller/templates/deployment.yml
@@ -142,8 +142,6 @@ spec:
         {{- with .Values.externalJobRunner }}
         - name: NP_KUBE_EXTERNAL_JOB_RUNNER_IMAGE
           value: {{ .image.repository }}:{{ .image.tag }}
-        - name: NP_KUBE_EXTERNAL_JOB_RUNNER_PORT
-          value: {{ .port | quote }}
         {{- end }}
         - name: NP_REGISTRY_URL
           value: {{ .Values.platform.registryUrl | quote }}

--- a/charts/platform-api-poller/templates/deployment.yml
+++ b/charts/platform-api-poller/templates/deployment.yml
@@ -139,6 +139,12 @@ spec:
         - name: NP_KUBE_IMAGE_PULL_SECRET
           value: {{ .Values.jobs.imagePullSecret | quote }}
         {{- end }}
+        {{- with .Values.externalJobRunner }}
+        - name: NP_KUBE_EXTERNAL_JOB_RUNNER_IMAGE
+          value: {{ .image.repository }}:{{ .image.tag }}
+        - name: NP_KUBE_EXTERNAL_JOB_RUNNER_PORT
+          value: {{ .port | quote }}
+        {{- end }}
         - name: NP_REGISTRY_URL
           value: {{ .Values.platform.registryUrl | quote }}
         {{- if .Values.platform.registryEmail }}

--- a/charts/platform-api-poller/values-dev.yaml
+++ b/charts/platform-api-poller/values-dev.yaml
@@ -20,6 +20,11 @@ jobs:
   ingressAuthMiddleware: platform-platform-ingress-auth@kubernetescrd
   ingressErrorPageMiddleware: platform-platform-web-ui-error-pages@kubernetescrd
 
+externalJobRunner:
+  image:
+    repository: ghcr.io/neuro-inc/externaljobrunner
+    tag: latest-dev
+
 storages:
 - type: pvc
   claimName: platform-storage

--- a/charts/platform-api-poller/values.yaml
+++ b/charts/platform-api-poller/values.yaml
@@ -35,7 +35,6 @@ externalJobRunner:
   image:
     repository: ghcr.io/neuro-inc/externaljobrunner
     tag: latest
-  port: 8080
 
 nodeLabels:
   job: platform.neuromation.io/job

--- a/charts/platform-api-poller/values.yaml
+++ b/charts/platform-api-poller/values.yaml
@@ -31,6 +31,12 @@ jobs:
   preemptibleTolerationKey:
   imagePullSecret:
 
+externalJobRunner:
+  image:
+    repository: ghcr.io/neuro-inc/externaljobrunner
+    tag: latest
+  port: 8080
+
 nodeLabels:
   job: platform.neuromation.io/job
   gpu: platform.neuromation.io/accelerator

--- a/platform_api/cluster_config_factory.py
+++ b/platform_api/cluster_config_factory.py
@@ -83,6 +83,7 @@ class ClusterConfigFactory:
                     gpu=preset.get("gpu"),
                     gpu_model=preset.get("gpu_model"),
                     tpu=self._create_tpu_preset(preset.get("tpu")),
+                    is_external_job=preset.get("is_external_job", False),
                 )
             )
         return result

--- a/platform_api/config_factory.py
+++ b/platform_api/config_factory.py
@@ -326,6 +326,16 @@ class EnvironConfigFactory:
             node_label_job=self._environ.get("NP_KUBE_NODE_LABEL_JOB"),
             node_label_node_pool=self._environ.get("NP_KUBE_NODE_LABEL_NODE_POOL"),
             image_pull_secret_name=self._environ.get("NP_KUBE_IMAGE_PULL_SECRET"),
+            external_job_runner_image=self._environ.get(
+                "NP_KUBE_EXTERNAL_JOB_RUNNER_IMAGE",
+                KubeConfig.external_job_runner_image,
+            ),
+            external_job_runner_port=int(
+                self._environ.get(
+                    "NP_KUBE_EXTERNAL_JOB_RUNNER_PORT",
+                    KubeConfig.external_job_runner_port,
+                )
+            ),
         )
 
     def create_registry(self) -> RegistryConfig:

--- a/platform_api/config_factory.py
+++ b/platform_api/config_factory.py
@@ -330,12 +330,6 @@ class EnvironConfigFactory:
                 "NP_KUBE_EXTERNAL_JOB_RUNNER_IMAGE",
                 KubeConfig.external_job_runner_image,
             ),
-            external_job_runner_port=int(
-                self._environ.get(
-                    "NP_KUBE_EXTERNAL_JOB_RUNNER_PORT",
-                    KubeConfig.external_job_runner_port,
-                )
-            ),
         )
 
     def create_registry(self) -> RegistryConfig:

--- a/platform_api/orchestrator/job.py
+++ b/platform_api/orchestrator/job.py
@@ -920,6 +920,11 @@ class Job:
     def is_restartable(self) -> bool:
         return self._record.is_restartable
 
+    @property
+    def is_external(self) -> bool:
+        preset = self.preset
+        return False if preset is None else preset.is_external_job
+
     def get_run_time(
         self, only_after: Optional[datetime] = None, now: Optional[datetime] = None
     ) -> timedelta:

--- a/platform_api/orchestrator/job.py
+++ b/platform_api/orchestrator/job.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 import hashlib
 import logging
@@ -6,7 +8,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from functools import partial
-from typing import Any, Optional
+from typing import Any
 
 import iso8601
 from yarl import URL
@@ -70,9 +72,9 @@ class JobStatusItem:
     status: JobStatus
     transition_time: datetime = field(compare=False)
     # TODO (A.Yushkovskiy) it's better to have `reason: Optional[JobStatusReason]`
-    reason: Optional[str] = None
-    description: Optional[str] = None
-    exit_code: Optional[int] = None
+    reason: str | None = None
+    description: str | None = None
+    exit_code: int | None = None
 
     @property
     def is_pending(self) -> bool:
@@ -95,15 +97,15 @@ class JobStatusItem:
         cls,
         status: JobStatus,
         *,
-        transition_time: Optional[datetime] = None,
+        transition_time: datetime | None = None,
         current_datetime_factory: Callable[[], datetime] = current_datetime_factory,
         **kwargs: Any,
-    ) -> "JobStatusItem":
+    ) -> JobStatusItem:
         transition_time = transition_time or current_datetime_factory()
         return cls(status=status, transition_time=transition_time, **kwargs)
 
     @classmethod
-    def from_primitive(cls, payload: dict[str, Any]) -> "JobStatusItem":
+    def from_primitive(cls, payload: dict[str, Any]) -> JobStatusItem:
         status = JobStatus(payload["status"])
         transition_time = iso8601.parse_date(payload["transition_time"])
         return cls(
@@ -138,18 +140,18 @@ class JobStatusHistory:
     @staticmethod
     def _find_with_status(
         items: Iterable[JobStatusItem], statuses: Sequence[JobStatus]
-    ) -> Optional[JobStatusItem]:
+    ) -> JobStatusItem | None:
         for item in items:
             if item.status in statuses:
                 return item
         return None
 
     @property
-    def _first_running(self) -> Optional[JobStatusItem]:
+    def _first_running(self) -> JobStatusItem | None:
         return self._find_with_status(self._items, (JobStatus.RUNNING,))
 
     @property
-    def _first_finished(self) -> Optional[JobStatusItem]:
+    def _first_finished(self) -> JobStatusItem | None:
         return self._find_with_status(
             self._items, (JobStatus.SUCCEEDED, JobStatus.CANCELLED, JobStatus.FAILED)
         )
@@ -186,7 +188,7 @@ class JobStatusHistory:
         return self.created_at.timestamp()
 
     @property
-    def started_at(self) -> Optional[datetime]:
+    def started_at(self) -> datetime | None:
         """Return a `datetime` when a job became RUNNING.
 
         In case the job terminated instantly without an explicit transition to
@@ -200,8 +202,8 @@ class JobStatusHistory:
         return None
 
     @property
-    def continued_at(self) -> Optional[datetime]:
-        result: Optional[JobStatusItem] = None
+    def continued_at(self) -> datetime | None:
+        result: JobStatusItem | None = None
         for item in reversed(self._items):
             if item.status == JobStatus.RUNNING:
                 result = item
@@ -210,7 +212,7 @@ class JobStatusHistory:
         return None
 
     @property
-    def started_at_str(self) -> Optional[str]:
+    def started_at_str(self) -> str | None:
         if self.started_at:
             return self.started_at.isoformat()
         return None
@@ -228,13 +230,13 @@ class JobStatusHistory:
         return self.last.is_finished
 
     @property
-    def finished_at(self) -> Optional[datetime]:
+    def finished_at(self) -> datetime | None:
         if self.last.is_finished:
             return self.last.transition_time
         return None
 
     @property
-    def finished_at_str(self) -> Optional[str]:
+    def finished_at_str(self) -> str | None:
         if self.finished_at:
             return self.finished_at.isoformat()
         return None
@@ -275,7 +277,7 @@ class JobPriority(enum.IntEnum):
         return self.name.lower()
 
     @classmethod
-    def from_name(cls, name: str) -> "JobPriority":
+    def from_name(cls, name: str) -> JobPriority:
         return cls[name.upper()]
 
 
@@ -287,26 +289,26 @@ class JobRecord:
     cluster_name: str
     project_name: str
     org_project_hash: bytes
-    org_name: Optional[str] = None
-    name: Optional[str] = None
-    preset_name: Optional[str] = None
+    org_name: str | None = None
+    name: str | None = None
+    preset_name: str | None = None
     tags: Sequence[str] = ()
     scheduler_enabled: bool = False
     preemptible_node: bool = False
     pass_config: bool = False
     materialized: bool = False
     privileged: bool = False
-    max_run_time_minutes: Optional[int] = None
-    internal_hostname: Optional[str] = None
-    internal_hostname_named: Optional[str] = None
-    schedule_timeout: Optional[float] = None
+    max_run_time_minutes: int | None = None
+    internal_hostname: str | None = None
+    internal_hostname_named: str | None = None
+    schedule_timeout: float | None = None
     restart_policy: JobRestartPolicy = JobRestartPolicy.NEVER
     priority: JobPriority = JobPriority.NORMAL
     energy_schedule_name: str = DEFAULT_ENERGY_SCHEDULE_NAME
 
     # Billing in credits
     fully_billed: bool = False  # True if job has final price
-    last_billed: Optional[datetime] = None
+    last_billed: datetime | None = None
     total_price_credits: Decimal = Decimal("0")
 
     # Retention (allows other services as platform-monitoring to cleanup jobs resources)
@@ -324,7 +326,7 @@ class JobRecord:
         current_datetime_factory: Callable[[], datetime] = current_datetime_factory,
         orphaned_job_owner: str = DEFAULT_ORPHANED_JOB_OWNER,
         **kwargs: Any,
-    ) -> "JobRecord":
+    ) -> JobRecord:
         if not kwargs.get("status_history"):
             status_history = JobStatusHistory(
                 [
@@ -344,9 +346,7 @@ class JobRecord:
         return cls(**kwargs)
 
     @classmethod
-    def _create_org_project_hash(
-        cls, org_name: Optional[str], project_name: str
-    ) -> bytes:
+    def _create_org_project_hash(cls, org_name: str | None, project_name: str) -> bytes:
         return cls._create_hash(org_name or NO_ORG, project_name)[:5]
 
     @classmethod
@@ -400,11 +400,11 @@ class JobRecord:
         return self.status_history.is_finished
 
     @property
-    def finished_at(self) -> Optional[datetime]:
+    def finished_at(self) -> datetime | None:
         return self.status_history.finished_at
 
     @property
-    def finished_at_str(self) -> Optional[str]:
+    def finished_at_str(self) -> str | None:
         return self.status_history.finished_at_str
 
     @property
@@ -412,13 +412,13 @@ class JobRecord:
         return bool(self.request.container.resources.gpu)
 
     @property
-    def gpu_model_id(self) -> Optional[str]:
+    def gpu_model_id(self) -> str | None:
         return self.request.container.resources.gpu_model_id
 
     def get_run_time(
         self,
         *,
-        only_after: Optional[datetime] = None,
+        only_after: datetime | None = None,
         current_datetime_factory: Callable[[], datetime] = current_datetime_factory,
     ) -> timedelta:
         def _filter_only_after(begin: datetime, end: datetime) -> timedelta:
@@ -429,7 +429,7 @@ class JobRecord:
             return timedelta()
 
         run_time = timedelta()
-        prev_time: Optional[datetime] = None
+        prev_time: datetime | None = None
         for item in self.status_history.all:
             if prev_time:
                 run_time += _filter_only_after(prev_time, item.transition_time)
@@ -531,7 +531,7 @@ class JobRecord:
         cls,
         payload: dict[str, Any],
         orphaned_job_owner: str = DEFAULT_ORPHANED_JOB_OWNER,
-    ) -> "JobRecord":
+    ) -> JobRecord:
         request = JobRequest.from_primitive(payload["request"])
         status_history = cls.create_status_history_from_primitive(
             request.job_id, payload
@@ -632,19 +632,19 @@ class Job:
         return self._job_request.job_id
 
     @property
-    def description(self) -> Optional[str]:
+    def description(self) -> str | None:
         return self._job_request.description
 
     @property
-    def name(self) -> Optional[str]:
+    def name(self) -> str | None:
         return self._name
 
     @property
-    def preset_name(self) -> Optional[str]:
+    def preset_name(self) -> str | None:
         return self._record.preset_name
 
     @property
-    def preset(self) -> Optional[Preset]:
+    def preset(self) -> Preset | None:
         try:
             return next(
                 preset
@@ -705,6 +705,10 @@ class Job:
         return self._job_request
 
     @property
+    def env(self) -> dict[str, str]:
+        return self._job_request.container.env
+
+    @property
     def volumes(self) -> Sequence[ContainerVolume]:
         return self._job_request.container.volumes
 
@@ -717,7 +721,7 @@ class Job:
         return self._record.has_gpu
 
     @property
-    def gpu_model_id(self) -> Optional[str]:
+    def gpu_model_id(self) -> str | None:
         return self._record.gpu_model_id
 
     @property
@@ -751,7 +755,7 @@ class Job:
         return self._status_history.is_finished
 
     @property
-    def finished_at(self) -> Optional[datetime]:
+    def finished_at(self) -> datetime | None:
         return self._status_history.finished_at
 
     @property
@@ -779,11 +783,11 @@ class Job:
         self._record.logs_removed = value
 
     @property
-    def schedule_timeout(self) -> Optional[float]:
+    def schedule_timeout(self) -> float | None:
         return self._record.schedule_timeout
 
     @property
-    def _collection_reason(self) -> Optional[str]:
+    def _collection_reason(self) -> str | None:
         status_item = self._status_history.current
         if status_item.status == JobStatus.PENDING:
             if status_item.reason == JobStatusReason.INVALID_IMAGE_NAME:
@@ -840,7 +844,7 @@ class Job:
         return f"{self.name}{JOB_NAME_SEPARATOR}{suffix}"
 
     @property
-    def http_host_named(self) -> Optional[str]:
+    def http_host_named(self) -> str | None:
         if not self.is_named:
             return None
         return self._orchestrator_config.jobs_domain_name_template.format(
@@ -859,22 +863,22 @@ class Job:
         return f"{self._http_scheme}://{self.http_host}"
 
     @property
-    def http_url_named(self) -> Optional[str]:
+    def http_url_named(self) -> str | None:
         assert self.has_http_server_exposed
         if host_named := self.http_host_named:
             return f"{self._http_scheme}://{host_named}"
         return None
 
     @property
-    def finished_at_str(self) -> Optional[str]:
+    def finished_at_str(self) -> str | None:
         return self._status_history.finished_at_str
 
     @property
-    def internal_hostname(self) -> Optional[str]:
+    def internal_hostname(self) -> str | None:
         return self._record.internal_hostname
 
     @property
-    def internal_hostname_named(self) -> Optional[str]:
+    def internal_hostname_named(self) -> str | None:
         return self._record.internal_hostname_named
 
     def init_job_internal_hostnames(self) -> None:
@@ -899,7 +903,7 @@ class Job:
         return self._preemptible_node
 
     @property
-    def energy_schedule_name(self) -> Optional[str]:
+    def energy_schedule_name(self) -> str | None:
         if self.scheduler_enabled:
             return self._record.energy_schedule_name
         return None
@@ -926,7 +930,7 @@ class Job:
         return False if preset is None else preset.is_external_job
 
     def get_run_time(
-        self, only_after: Optional[datetime] = None, now: Optional[datetime] = None
+        self, only_after: datetime | None = None, now: datetime | None = None
     ) -> timedelta:
         def datetime_factory() -> datetime:
             if now:
@@ -940,7 +944,7 @@ class Job:
         )
 
     @property
-    def max_run_time_minutes(self) -> Optional[int]:
+    def max_run_time_minutes(self) -> int | None:
         return self._record.max_run_time_minutes
 
     @property
@@ -948,7 +952,7 @@ class Job:
         return self._record.fully_billed
 
     @property
-    def last_billed(self) -> Optional[datetime]:
+    def last_billed(self) -> datetime | None:
         return self._record.last_billed
 
     @property
@@ -956,7 +960,7 @@ class Job:
         return self._record.total_price_credits
 
     @property
-    def org_name(self) -> Optional[str]:
+    def org_name(self) -> str | None:
         return self._record.org_name
 
     @property
@@ -979,7 +983,7 @@ class Job:
         cls,
         orchestrator_config: OrchestratorConfig,
         payload: dict[str, Any],
-    ) -> "Job":
+    ) -> Job:
         record = JobRecord.from_primitive(payload)
         return cls(
             orchestrator_config=orchestrator_config,

--- a/platform_api/orchestrator/kube_config.py
+++ b/platform_api/orchestrator/kube_config.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import enum
-from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 class KubeClientAuthType(str, enum.Enum):
@@ -46,8 +45,8 @@ class KubeConfig:
     image_pull_secret_name: str | None = None
 
     external_job_runner_image: str = "ghcr.io/neuro-inc/externaljobrunner:latest"
-    external_job_runner_command: Sequence[str] = ()
-    external_job_runner_args: Sequence[str] = ()
+    external_job_runner_command: list[str] = field(default_factory=list)
+    external_job_runner_args: list[str] = field(default_factory=list)
     external_job_runner_port: int = 8080
 
     def __post_init__(self) -> None:

--- a/platform_api/orchestrator/kube_config.py
+++ b/platform_api/orchestrator/kube_config.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import enum
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Optional
 
 
 class KubeClientAuthType(str, enum.Enum):
@@ -12,14 +14,14 @@ class KubeClientAuthType(str, enum.Enum):
 @dataclass(frozen=True)
 class KubeConfig:
     endpoint_url: str
-    cert_authority_data_pem: Optional[str] = None
-    cert_authority_path: Optional[str] = None
+    cert_authority_data_pem: str | None = None
+    cert_authority_path: str | None = None
 
     auth_type: KubeClientAuthType = KubeClientAuthType.NONE
-    auth_cert_path: Optional[str] = None
-    auth_cert_key_path: Optional[str] = None
-    token: Optional[str] = None
-    token_path: Optional[str] = None
+    auth_cert_path: str | None = None
+    auth_cert_key_path: str | None = None
+    token: str | None = None
+    token_path: str | None = None
 
     namespace: str = "default"
 
@@ -31,17 +33,22 @@ class KubeConfig:
     jobs_ingress_auth_middleware: str = "ingress-auth@kubernetescrd"
     jobs_ingress_error_page_middleware: str = "error-page@kubernetescrd"
     jobs_pod_job_toleration_key: str = "platform.neuromation.io/job"
-    jobs_pod_preemptible_toleration_key: Optional[str] = None
-    jobs_pod_priority_class_name: Optional[str] = None
+    jobs_pod_preemptible_toleration_key: str | None = None
+    jobs_pod_priority_class_name: str | None = None
 
     storage_volume_name: str = "storage"
 
-    node_label_gpu: Optional[str] = None
-    node_label_preemptible: Optional[str] = None
-    node_label_job: Optional[str] = None
-    node_label_node_pool: Optional[str] = None
+    node_label_gpu: str | None = None
+    node_label_preemptible: str | None = None
+    node_label_job: str | None = None
+    node_label_node_pool: str | None = None
 
-    image_pull_secret_name: Optional[str] = None
+    image_pull_secret_name: str | None = None
+
+    external_job_runner_image: str = "ghcr.io/neuro-inc/externaljobrunner:latest"
+    external_job_runner_command: Sequence[str] = ()
+    external_job_runner_args: Sequence[str] = ()
+    external_job_runner_port: int = 8080
 
     def __post_init__(self) -> None:
         if not self.endpoint_url:

--- a/platform_api/orchestrator/kube_config.py
+++ b/platform_api/orchestrator/kube_config.py
@@ -47,7 +47,6 @@ class KubeConfig:
     external_job_runner_image: str = "ghcr.io/neuro-inc/externaljobrunner:latest"
     external_job_runner_command: list[str] = field(default_factory=list)
     external_job_runner_args: list[str] = field(default_factory=list)
-    external_job_runner_port: int = 8080
 
     def __post_init__(self) -> None:
         if not self.endpoint_url:

--- a/platform_api/orchestrator/kube_orchestrator.py
+++ b/platform_api/orchestrator/kube_orchestrator.py
@@ -722,6 +722,8 @@ class KubeOrchestrator(Orchestrator):
         if pod_status.is_finished:
             return pod_status
 
+        # Job is in terminating/terminated but pod phase has not moved to
+        # succeeded/failed yet, continue returning running status.
         if job.is_running:
             return job.status_history.last
 

--- a/platform_api/orchestrator/kube_orchestrator.py
+++ b/platform_api/orchestrator/kube_orchestrator.py
@@ -706,7 +706,7 @@ class KubeOrchestrator(Orchestrator):
         now = datetime.now(timezone.utc)
 
         try:
-            port = self._kube_config.external_job_runner_port
+            port = int(job.env.get("EXTERNAL_JOB_RUNNER_PORT", 8080))
             status_url = f"http://{job.internal_hostname}:{port}/api/v1/status"
             resp = await self._client.request("GET", status_url, raise_for_status=True)
             return JobStatusItem.create(

--- a/platform_api/resource.py
+++ b/platform_api/resource.py
@@ -43,6 +43,7 @@ class Preset:
     gpu: Optional[int] = None
     gpu_model: Optional[str] = None
     tpu: Optional[TPUPreset] = None
+    is_external_job: bool = False
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_cluster_config_factory.py
+++ b/tests/unit/test_cluster_config_factory.py
@@ -367,6 +367,7 @@ class TestClusterConfigFactory:
                 "memory": 49152 * 10**6,
                 "scheduler_enabled": True,
                 "preemptible_node": True,
+                "is_external_job": True,
             },
         ]
         clusters = factory.create_cluster_configs(clusters_payload)
@@ -379,6 +380,7 @@ class TestClusterConfigFactory:
                 memory=49152 * 10**6,
                 scheduler_enabled=True,
                 preemptible_node=True,
+                is_external_job=True,
             ),
         ]
         assert clusters[0].orchestrator.allow_scheduler_enabled_job is True

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -602,6 +602,10 @@ class TestEnvironConfigFactory:
                 "NP_KUBE_NODE_LABEL_PREEMPTIBLE": "preemptible-label",
                 "NP_KUBE_NODE_LABEL_NODE_POOL": "node-pool-label",
                 "NP_KUBE_IMAGE_PULL_SECRET": "test-secret",
+                "NP_KUBE_EXTERNAL_JOB_RUNNER_IMAGE": (
+                    "custom-external-job-runner:latest"
+                ),
+                "NP_KUBE_EXTERNAL_JOB_RUNNER_PORT": "9090",
             }
         ).create_kube()
 
@@ -628,6 +632,8 @@ class TestEnvironConfigFactory:
             node_label_preemptible="preemptible-label",
             node_label_node_pool="node-pool-label",
             image_pull_secret_name="test-secret",
+            external_job_runner_image="custom-external-job-runner:latest",
+            external_job_runner_port=9090,
         )
 
     def test_create_zipkin_none(self) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -605,7 +605,6 @@ class TestEnvironConfigFactory:
                 "NP_KUBE_EXTERNAL_JOB_RUNNER_IMAGE": (
                     "custom-external-job-runner:latest"
                 ),
-                "NP_KUBE_EXTERNAL_JOB_RUNNER_PORT": "9090",
             }
         ).create_kube()
 
@@ -633,7 +632,6 @@ class TestEnvironConfigFactory:
             node_label_node_pool="node-pool-label",
             image_pull_secret_name="test-secret",
             external_job_runner_image="custom-external-job-runner:latest",
-            external_job_runner_port=9090,
         )
 
     def test_create_zipkin_none(self) -> None:


### PR DESCRIPTION
For regular jobs platform-api-poller maps pod status to job status. But for external jobs it's not possible since actual workload is done outside of the cluster.
For external jobs platform-api-poller listens to job status endpoint which is exposed by external job runner pod while it is running. But when the job stops external job runner saves termination status (exit code and message) to pod status and platform-api-poller can now map pod status to job status.