### PR TITLE
NodeResourcesHandler takes into account failed pods

### DIFF
--- a/platform_api/orchestrator/kube_client.py
+++ b/platform_api/orchestrator/kube_client.py
@@ -1709,13 +1709,7 @@ class Node:
         )
 
     def get_free_resources(self, resource_requests: NodeResources) -> NodeResources:
-        try:
-            return self.status.allocatable_resources - resource_requests
-        except ValueError:
-            logger.warning(
-                f"Failed to compute free resources for {self=}: {resource_requests=}"
-            )
-            raise
+        return self.status.allocatable_resources - resource_requests
 
 
 @dataclass(frozen=True)

--- a/platform_api/orchestrator/kube_client.py
+++ b/platform_api/orchestrator/kube_client.py
@@ -1485,6 +1485,10 @@ class PodStatus:
         return self.phase == "Pending"
 
     @property
+    def is_phase_failed(self) -> bool:
+        return self.phase == "Failed"
+
+    @property
     def is_scheduled(self) -> bool:
         if not self.is_phase_pending:
             return True

--- a/platform_api/orchestrator/kube_orchestrator_scheduler.py
+++ b/platform_api/orchestrator/kube_orchestrator_scheduler.py
@@ -110,7 +110,11 @@ class NodeResourcesHandler(EventHandler):
         pod = _Pod(event.resource)
         if pod.is_idle or not pod.status.is_scheduled:
             return
-        if event.type == WatchEventType.DELETED or pod.status.is_terminated:
+        if (
+            event.type == WatchEventType.DELETED
+            or pod.status.is_terminated
+            or pod.status.is_phase_failed
+        ):
             self._remove_pod(pod)
         else:
             self._add_pod(pod)

--- a/platform_api/orchestrator/kube_orchestrator_scheduler.py
+++ b/platform_api/orchestrator/kube_orchestrator_scheduler.py
@@ -103,6 +103,7 @@ class NodeResourcesHandler(EventHandler):
                 not pod.is_idle
                 and pod.status.is_scheduled
                 and not pod.status.is_terminated
+                and not pod.status.is_phase_failed
             ):
                 self._add_pod(pod)
 


### PR DESCRIPTION
Observed this error on dev cluster, which might be caused by custodian changing the state of the cluster.

When cluster is recreated, k8s schedules all service pods, not all of them are able to fit nodes that are rolling out sequentially.

Some of those pods being scheduled at 1st available node does not fit and get into "Failed" state with `OutOfcpu` error status. 
Failed pod in this case is not removed by k8s and stays bound to node.

This created resource leakage in our NodeResourcesHandler since we did not handle such event.